### PR TITLE
Add slideChange event

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -157,6 +157,7 @@
 		}
 
 		if (updateSlider == true) {
+			var old = this.getValue();
 			var val = this.calculateValue();
 			this.element
 				.trigger({
@@ -165,6 +166,17 @@
 				})
 				.data('value', val)
 				.prop('value', val);
+
+			if (old != val) {
+				this.element
+                    .trigger({
+                        type: 'slideChange',
+                        new: val,
+                        old: old
+                    })
+                    .data('value', val)
+                    .prop('value', val);
+			}
 		}
 	};
 


### PR DESCRIPTION
slideChange event is fired only when the slider value changes as a result of dragging. This is useful because many listeners to the side event only need to perform an action when the value has changed.
