### PR TITLE
Constrain values to bounds

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -354,6 +354,11 @@
 				this.value = val;
 			} else {
 				val = (this.min + Math.round((this.diff * this.percentage[0]/100)/this.step)*this.step);
+                if (val < this.min) {
+                    val = this.min;
+                else if (val > this.max) {
+                    val = this.max;
+                }
 				this.value = [val, this.value[1]];
 			}
 			return val;


### PR DESCRIPTION
I noticed that the range slider values can go beyond the specified min/max values by 1, I imagine this is due to rounding, eg with a min/max values of 1 & 100 I see the slider going to 0 and 101.

I've only used the range slider so haven't tested the fix for the normal slider but it should be ok.
