### PR TITLE
The slideStop event now emits AFTER modifying the element data attribute

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -356,12 +356,12 @@
 			var val = this.calculateValue();
 			this.layout();
 			this.element
+				.data('value', val)
+				.prop('value', val)
 				.trigger({
 					type: 'slideStop',
 					value: val
-				})
-				.data('value', val)
-				.prop('value', val);
+				});
 			return false;
 		},
 


### PR DESCRIPTION
Hi, 

Before this change, the "slideStop" event fired BEFORE the data attribute was changed to the 
selected value. 

Consider the following code:

```
    var $slider = $("#side-slider").slider();
    $slider.on('slideStop',function(e) {
        console.log($(this).val());
    });
```

Because the event is being emitted before the element is modified, the first time 
that you click on a slider $(this).val() will return "empty string" , the second time it will 
return the value as it was on the first click ( the previous slider position value) and so on. 

This patch changes the behavior so that "slideStop" is emitted after modifying the 
element attributes.

Ran grunt test an all still checks out fine 
## Thanks !

Cillier Burger
