### PR TITLE
Some minor fixes that causes errors in IE8 and IE9

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -86,7 +86,8 @@
 		}
 
 		['min', 'max', 'step', 'value'].forEach(function(attr) {
-			this[attr] = el.data('slider-' + attr) || options[attr] || el.prop(attr);
+            // the "|| 0" is used when the expression before it evaluates to an empty string (causes bad calculations in IE later on)
+			this[attr] = el.data('slider-' + attr) || options[attr] || el.prop(attr) || 0;
 		}, this);
 
 		if (this.value instanceof Array) {
@@ -171,8 +172,8 @@
 			var val = this.calculateValue();
 			this.element
 				.trigger({
-					type: 'slide',
-					value: val
+					'type': 'slide',
+					'value': val
 				})
 				.data('value', val)
 				.prop('value', val);
@@ -180,9 +181,9 @@
 			if (old !== val) {
 				this.element
 					.trigger({
-						type: 'slideChange',
-						new: val,
-						old: old
+						'type': 'slideChange',
+						'new': val, // without a string literal, IE8 will interpret as the JS "new" keyword
+						'old': old
 					})
 					.data('value', val)
 					.prop('value', val);


### PR DESCRIPTION
Hi seiyria,

Here are some small changes I did to make the slider library at work in IE8 and IE9 (haven't tested IE10).

The first change is that the expression can cause properties like this.min to be set to a blank string. In IE8/9 when the blank string is later used in math calculations, it would result in NaN and causing issues like the slider handle to not position and work properly.

The second change is that the "new" object key is being interpreted as the JS keyword in IE8, causing an error when the library is loaded. So it's being written as a String literal. Please feel free to change the object key name instead if that solution suits you better.

Thanks!
