### PR TITLE
Fix bug that prevents option values of 0 being parsed correctly

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -86,11 +86,11 @@
 		}
 
 		['min', 'max', 'step', 'value'].forEach(function(attr) {
-			if (el.data('slider-' + attr) != 'undefined') {
+			if (typeof el.data('slider-' + attr) !== 'undefined') {
 				this[attr] = el.data('slider-' + attr);
-			} else if (options[attr] != 'undefined') {
+			} else if (typeof options[attr] !== 'undefined') {
 				this[attr] = options[attr];
-			} else if (el.prop(attr) != 'undefined') {
+			} else if (typeof el.prop(attr) !== 'undefined') {
 				this[attr] = el.prop(attr);
 			} else {
 				this[attr] = 0; // to prevent empty string issues in calculations in IE


### PR DESCRIPTION
The previous || parsing of the option values would ignore values that evaluate to false e.g. 0 values
