### PR TITLE
Added getMin, setMin, getMax, setMax methods

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -454,7 +454,7 @@
 		setMax: function(val) {
 			this.max = val;
 			this.setValue(this.getValue());
-		}
+		},
 
 		validateInputValue : function(val) {
 			if(typeof val === 'number') {


### PR DESCRIPTION
These methods allow the minimum and maximum value of the slider to be changed without having to re-create and destroy the slider. The slider's visuals are correctly re-calculated after a value changes (the value itself does not change).

Changes added because I wanted these features for my own project.

Referencing issue #33 because it appears to be asking about exactly this sort of feature.
