### PR TITLE
fixes a bug that prevents to get the max/min value when the max percenta...

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -381,7 +381,7 @@
 			if (this.range) {
 				val = [this.min,this.max];
                 if (this.percentage[0] !== 0){
-                    val[0] = (Math.max(this.min, this.min + Math.round((this.diff * this.percentage[0]/100)/this.step)*this.step))
+                    val[0] = (Math.max(this.min, this.min + Math.round((this.diff * this.percentage[0]/100)/this.step)*this.step));
                 }
                 if (this.percentage[1] !== 100){
                     val[1] = (Math.min(this.max, this.min + Math.round((this.diff * this.percentage[1]/100)/this.step)*this.step));


### PR DESCRIPTION
Hi Kyle
could you review this fix for  little bug that happens when the user is using a range slider and moves the handles to the min or  max positions, and the sliders doesn't exactly sets the values to the configured min and max values
