### PR TITLE
IE8 bugfix: changed use of .forEach to jQ $.each()

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -85,17 +85,18 @@
 				break;
 		}
 
-		['min', 'max', 'step', 'value'].forEach(function(attr) {
+    var self = this;
+		$.each(['min', 'max', 'step', 'value'], function(i, attr) {
 			if (typeof el.data('slider-' + attr) !== 'undefined') {
-				this[attr] = el.data('slider-' + attr);
+				self[attr] = el.data('slider-' + attr);
 			} else if (typeof options[attr] !== 'undefined') {
-				this[attr] = options[attr];
+				self[attr] = options[attr];
 			} else if (typeof el.prop(attr) !== 'undefined') {
-				this[attr] = el.prop(attr);
+				self[attr] = el.prop(attr);
 			} else {
-				this[attr] = 0; // to prevent empty string issues in calculations in IE
+				self[attr] = 0; // to prevent empty string issues in calculations in IE
 			}
-		}, this);
+		});
 
 		if (this.value instanceof Array) {
 			this.range = true;
@@ -448,7 +449,7 @@
 			if(typeof val === 'number') {
 				return val;
 			} else if(val instanceof Array) {
-				val.forEach(function(input) { if (typeof input !== 'number') { throw new Error( ErrorMsgs.formatInvalidInputErrorMsg(input) ); }});
+				$.each(val, function(i, input) { if (typeof input !== 'number') { throw new Error( ErrorMsgs.formatInvalidInputErrorMsg(input) ); }});
 				return val;
 			} else {
 				throw new Error( ErrorMsgs.formatInvalidInputErrorMsg(val) );


### PR DESCRIPTION
I'm trying to do some early browser testing on some dynamic pages I'm creating which use this slider widget. Problem I found, is that the use of .forEach causes them to not work in IE8. 

I've changed it to jQuery each, which offers the same functionality in a more browser friendly way. 

I think my code could get cleaned up and avoid self...but code is here for review.
