### PR TITLE
Enhanced and added tests for #79

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -586,12 +586,15 @@
 	}
 
 	function createNewSliderInstance(opts) {
-		var $this = $(this),
-			data = $this.data('slider'),
-			options = typeof opts === 'object' && opts;
-		if (!data)  {
-			$this.data('slider', (data = new Slider(this, $.extend({}, $.fn.slider.defaults,options))));
-		}
+		var $this = $(this);
+		$this.each(function() {
+			var $this = $(this),
+				data = $this.data('slider'),
+				options = typeof opts === 'object' && opts;
+			if (!data)  {
+				$this.data('slider', (data = new Slider(this, $.extend({}, $.fn.slider.defaults,options))));
+			}
+		});
 		return $this;
 	}
 

--- a/spec/PublicMethodsSpec.js
+++ b/spec/PublicMethodsSpec.js
@@ -14,6 +14,17 @@ describe("Public Method Tests", function() {
       expect(sliderInstanceHasExpectedId).toBeTruthy();
     });
 
+    it("generates multiple slider instances from selector", function() {
+
+      $(".makeSlider").slider();
+
+      var sliderInstancesExists = $(".makeSlider").parent().is(".slider");
+      expect(sliderInstancesExists).toBeTruthy();
+
+      var sliderInstancesCount = $(".makeSlider").parent(".slider").length;
+      expect(sliderInstancesCount).toEqual(2);
+    });
+
     it("reads and sets the 'min' option properly", function() {
       var minVal = -5;
 

--- a/tpl/SpecRunner.tpl
+++ b/tpl/SpecRunner.tpl
@@ -16,6 +16,8 @@
 	<!-- Slider used for PublicMethodsSpec and EventsSpec -->
 	<input id="testSlider1" type="text"/>
 	<input id="testSlider2" type="text"/>
+    <input class="makeSlider" type="text"/>
+    <input class="makeSlider" type="text"/>
 
 	<!-- Sliders used for ElementDataSttributesSpec -->
 	<input id="minSlider" type="text" data-slider-min="5"/>


### PR DESCRIPTION
Inspired by #79 (a fix for #77), modification allows multiple sliders to be created, while preserving function chaining. Included a couple tests to make sure the sliders were created. I know more tests would be better, but these at least show the multi-selector generates multiple sliders.
