### PR TITLE
Avoid division by zero

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -184,8 +184,8 @@
 				this.step * 100 / this.diff
 			];
 		} else {
-      this.percentage = [0, 0, 0];
-    }
+			this.percentage = [0, 0, 100];
+		}
 
 		this.offset = this.picker.offset();
 		this.size = this.picker[0][this.sizePos];
@@ -584,8 +584,8 @@
 					this.step * 100 / this.diff
 				];
 			} else {
-			  this.percentage = [0, 0, 0];
-      }
+				this.percentage = [0, 0, 100];
+			}
 
 			this.layout();
 
@@ -744,3 +744,5 @@
 	$.fn.slider.Constructor = Slider;
 
 })( window.jQuery );
+
+/* vim: set noexpandtab tabstop=4 shiftwidth=4 autoindent: */


### PR DESCRIPTION
In some cases where diff between max and min can be zero (e.g. when used with mutable collections where items are deleted), the library will attempt a division by zero, resulting in `this.percentages` to contain `NaN` or `Infinity` values. This adds a check, defaulting to `[0, 0, 0]`.
