### PR TITLE
Add correct notation for strict maths

### DIFF
--- a/less/bootstrap-slider.less
+++ b/less/bootstrap-slider.less
@@ -18,9 +18,9 @@
 		width: 210px;
 		height: @slider-line-height;
 		.slider-track {
-			height: @slider-line-height/2;
+			height: (@slider-line-height/2);
 			width: 100%;
-			margin-top: -@slider-line-height/4;
+			margin-top: (-@slider-line-height/4);
 			top: 50%;
 			left: 0;
 		}
@@ -30,10 +30,10 @@
 			bottom: 0;
 		}
 		.slider-handle {
-			margin-left: -@slider-line-height/2;
-			margin-top: -@slider-line-height/4;
+			margin-left: (-@slider-line-height/2);
+			margin-top: (-@slider-line-height/4);
 			&.triangle {
-    			border-width: 0 @slider-line-height/2 @slider-line-height/2 @slider-line-height/2;
+				border-width: 0 (@slider-line-height/2) (@slider-line-height/2) (@slider-line-height/2);
 				width: 0;
 				height: 0;
 				border-bottom-color: #0480be;
@@ -45,9 +45,9 @@
 		height: 210px;
 		width: @slider-line-height;
 		.slider-track {
-			width: @slider-line-height/2;
+			width: (@slider-line-height/2);
 			height: 100%;
-			margin-left: -@slider-line-height/4;
+			margin-left: (-@slider-line-height/4);
 			left: 50%;
 			top: 0;
 		}
@@ -58,10 +58,10 @@
 			bottom: 0;
 		}
 		.slider-handle {
-			margin-left: -@slider-line-height/4;
-			margin-top: -@slider-line-height/2;
+			margin-left: (-@slider-line-height/4);
+			margin-top: (-@slider-line-height/2);
 			&.triangle {
-				border-width: @slider-line-height/2 0 @slider-line-height/2 @slider-line-height/2;
+				border-width: (@slider-line-height/2) 0 (@slider-line-height/2) (@slider-line-height/2);
 				width: 1px;
 				height: 1px;
 				border-left-color: #0480be;


### PR DESCRIPTION
As bootstrap is built using strict maths we should use do the same. For anyone using grunt and strict maths to compile their code not having the brackets could result in css which isn't valid being output for example height: 20px/2;
