### PR TITLE
Prevent fractional margin-left

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -286,13 +286,13 @@
 				if (this.orientation === 'vertical') {
 					this.tooltip.css('margin-top', -this.tooltip.outerHeight() / 2 + 'px');
 				} else {
-					this.tooltip.css('margin-left', -this.tooltip.outerWidth() / 2 + 'px');
+					this.tooltip.css('margin-left', -Math.floor(this.tooltip.outerWidth() / 2) + 'px');
 				}
 				
 				if (this.orientation === 'vertical') {
 					this.tooltip.css('margin-top', -this.tooltip.outerHeight() / 2 + 'px');
 				} else {
-					this.tooltip.css('margin-left', -this.tooltip.outerWidth() / 2 + 'px');
+					this.tooltip.css('margin-left', -Math.floor(this.tooltip.outerWidth() / 2) + 'px');
 				}
 				this.tooltipInner_min.text(
 					this.formater(this.value[0])
@@ -305,13 +305,13 @@
 				if (this.orientation === 'vertical') {
 					this.tooltip_min.css('margin-top', -this.tooltip_min.outerHeight() / 2 + 'px');
 				} else {
-					this.tooltip_min.css('margin-left', -this.tooltip_min.outerWidth() / 2 + 'px');
+					this.tooltip_min.css('margin-left', -Math.floor(this.tooltip_min.outerWidth() / 2) + 'px');
 				}
 				this.tooltip_max[0].style[this.stylePos] = positionPercentages[1] + '%';
 				if (this.orientation === 'vertical') {
 					this.tooltip_max.css('margin-top', -this.tooltip_max.outerHeight() / 2 + 'px');
 				} else {
-					this.tooltip_max.css('margin-left', -this.tooltip_max.outerWidth() / 2 + 'px');
+					this.tooltip_max.css('margin-left', -Math.floor(this.tooltip_max.outerWidth() / 2) + 'px');
 				}
 			} else {
 				this.tooltipInner.text(
@@ -321,7 +321,7 @@
 				if (this.orientation === 'vertical') {
 					this.tooltip.css('margin-top', -this.tooltip.outerHeight() / 2 + 'px');
 				} else {
-					this.tooltip.css('margin-left', -this.tooltip.outerWidth() / 2 + 'px');
+					this.tooltip.css('margin-left', -Math.floor(this.tooltip.outerWidth() / 2) + 'px');
 				}
 			}
 		},


### PR DESCRIPTION
Fix bug with tooltip having a vertical line.  Don't compute `margin-left` in fractional pixels.
![image](https://cloud.githubusercontent.com/assets/2387520/3500738/4f608b02-060e-11e4-8c6c-074096799f72.png)
