### PR TITLE
Remove the @imports from bootstrap-slider.less

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Clone the repository, then run `npm install`
 
 Want to use bower? `bower install seiyria-bootstrap-slider`
 
+
+Include the javascript in your html (obviously) and the less file in your less stylesheet.  bootstrap-slider will use values defined in variables.less and mixins.less, so ensure that they're available (if we're using bootstrap, bower, and less, then these are likely already available).
+
+```less
+// adjust to taste
+@import "../bower_components/seiyria-bootstrap-slider/less/bootstrap-slider.less";
+```
+
 Examples
 ========
 You can see all of our API examples [here](http://seiyria.github.io/bootstrap-slider/).

--- a/less/bootstrap-slider.less
+++ b/less/bootstrap-slider.less
@@ -4,9 +4,6 @@
  * Licensed under the Apache License v2.0
  *
  */
-//@import '../bower_components/bootstrap/less/variables.less';
-@import 'variables.less'; // Bootstrap variables
-@import 'mixins.less';    // Bootstrap mixins
 
 @slider-line-height: @line-height-computed;
 


### PR DESCRIPTION
… because we don't want to edit anything bower_components, and gulp chokes on the missing dependencies.  If we're using bootstrap, bower, and less, then these are already available.

hth… let me know if I'm barking up the wrong tree!

tx for the project :)

Fixes:

```
[12:54:29] gulp-notify: [Error running Gulp] Error: 'variables.less' wasn't found in file /Users/snip/static/app/bower_components/seiyria-bootstrap-slider/less/bootstrap-slider.less line no. 8
```
