### PR TITLE
pass callback into the array

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -702,7 +702,7 @@
 				if(callbacksArray) {
 					callbacksArray.push(callback);
 				} else {
-					this.eventToCallbackMap[evt] = [];
+					this.eventToCallbackMap[evt] = [callback];
 				}
 			},
 			_cleanUpEventCallbacksMap: function() {


### PR DESCRIPTION
This is the fix for non-jquery version. When you were binding events you were passing an empty array.
