### PR TITLE
Fix for Windows 8 touch enabled laptops.

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -450,11 +450,10 @@
 				// Bind touch handlers
 				this.mousedown = this._mousedown.bind(this);
 				this.sliderElem.addEventListener("touchstart", this.mousedown, false);
-			} else {
-				// Bind mouse handlers
-				this.mousedown = this._mousedown.bind(this);
-				this.sliderElem.addEventListener("mousedown", this.mousedown, false);
 			}
+                        // Bind mouse handlers
+                        this.mousedown = this._mousedown.bind(this);
+                        this.sliderElem.addEventListener("mousedown", this.mousedown, false);
 
 			// Bind tooltip-related handlers
 			if(this.options.tooltip === 'hide') {
@@ -850,11 +849,10 @@
 					// Touch: Bind touch events:
 					document.addEventListener("touchmove", this.mousemove, false);
 					document.addEventListener("touchend", this.mouseup, false);
-				} else {
-					// Bind mouse events:
-					document.addEventListener("mousemove", this.mousemove, false);
-					document.addEventListener("mouseup", this.mouseup, false);
 				}
+                                // Bind mouse events:
+                                document.addEventListener("mousemove", this.mousemove, false);
+                                document.addEventListener("mouseup", this.mouseup, false);
 
 				this.inDrag = true;
 
@@ -976,11 +974,10 @@
 					// Touch: Unbind touch event handlers:
 					document.removeEventListener("touchmove", this.mousemove, false);
 					document.removeEventListener("touchend", this.mouseup, false);
-				} else {
-					// Unbind mouse event handlers:
-					document.removeEventListener("mousemove", this.mousemove, false);
-					document.removeEventListener("mouseup", this.mouseup, false);
 				}
+                                // Unbind mouse event handlers:
+                                document.removeEventListener("mousemove", this.mousemove, false);
+                                document.removeEventListener("mouseup", this.mouseup, false);
 				
 				this.inDrag = false;
 				if (this.over === false) {


### PR DESCRIPTION
Hi,

This week I had to look into this issue for multiple times when my customer said that slider didn't work in his Windows laptop with Firefox. Next more detailed information was that slider didn't work on his Windows 8 laptop with Firefox. 

Then I downloaded Windows 8.1 from modern.ie and installed Firefox and tested this issue using Virtualbox, everything worked as it should, but my customer still said that it didn't work. 

Then in this morning he said that slider did actually work when used through touching the laptops screen, then I knew that I needed to look into this slider.js more closely and noticed that if user has a 'touchenabled' device then no mouse events are attached.

I needed to fix the code as you can see in this pull request. This version will work also on Windows 8 laptops which many of them are touch enabled + those have mouse capability.

I didn't see any need to alter the test because doesn't add any new code, current tests are passing though.

I hope that you could add these changes to the master repo so that everybody can enjoy using this slider with Windows 8 laptops.

Br,
Markku Roponen

ps. more information about this issue. http://www.html5rocks.com/en/mobile/touchandmouse/
"Devices such as the Chromebook Pixel and some Windows 8 laptops now support BOTH Mouse and Touch input methods, and more will in the near future."
