### PR TITLE
Slider changes from normal to range with a refresh [fix]

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -401,12 +401,20 @@
 				this.tooltip_max.style.top = -this.tooltip_max.outerHeight - 14 + 'px';
 			}
 
-			if (this.options.value instanceof Array) {
-				this.options.range = true;
-			} else if (this.options.range) {
-				// User wants a range, but value is not an array
-				this.options.value = [this.options.value, this.options.max];
-			}
+			// Fix issue, setValue chnage the value always into an array, on refresh normal slider changes in range slider.
+                        // downsinde of this fix you can not change a normal slider into a range slider
+                        if (updateSlider === true && !this.options.range) { 
+                            if (this.options.value instanceof Array) {
+                                this.options.value = this.options.value[0];
+                            }
+                        } else { // end fix
+                            if (this.options.value instanceof Array) {
+                                    this.options.range = true;
+                            } else if (this.options.range) {
+                                    // User wants a range, but value is not an array
+                                    this.options.value = [this.options.value, this.options.max];
+                            }
+                        }
 
 			this.trackSelection = sliderTrackSelection || this.trackSelection;
 			if (this.options.selection === 'none') {


### PR DESCRIPTION
Fix issue, setValue change the value always into an array, on refresh normal slider changes it into range slider.
downsinde of this fix; you can not change a normal slider into a range slider anymore with an update.

Problem:
http://jsfiddle.net/6y67z1ex/

Fix: http://jsfiddle.net/6y67z1ex/1/

Info:
```js
_slider = new Slider("value":5); //->call setValue

setValue: function(val, triggerSlideEvent) {
    // ......
    if (this.options.range) {
        //.......
    } else {
        this.options.value = applyPrecision(this.options.value);
        this.options.value = [Math.max(this.options.min, Math.min(this.options.max, this.options.value))]; //value is now an array!!!
        this._addClass(this.handle2, 'hide');
        if (this.options.selection === 'after') {
            this.options.value[1] = this.options.max;
        } else {
            this.options.value[1] = this.options.min;
        }
    }
    //....
}

slider.refresh(); // call constructor

function createNewSlider(element, options) {
    //.....
    if (this.options.value instanceof Array) { // now on refresh it changes it into an range slider!
        this.options.range = true;
    }
    // ....
}
```