### PR TITLE
Referencing import directives to the bootstrap directory

### DIFF
--- a/less/bootstrap-slider.less
+++ b/less/bootstrap-slider.less
@@ -23,9 +23,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  * ========================================================= */
-//@import '../bower_components/bootstrap/less/variables.less';
-@import 'variables.less'; // Bootstrap variables
-@import 'mixins.less';    // Bootstrap mixins
+
+@import '../../bootstrap/less/variables.less'; // Bootstrap variables
+@import '../../bootstrap/less/mixins.less';    // Bootstrap mixins
 
 @slider-line-height: @line-height-computed;
 


### PR DESCRIPTION
#176 Since we install bootstrap as bower dependency we should reference less imports directly.
