### PR TITLE
Clean mousemove and mouseup events

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -841,6 +841,18 @@
 
 				this.percentage[this.dragged] = this.options.reversed ? 100 - percentage : percentage;
 				this._layout();
+				
+				if (this.touchCapable) {
+					document.removeEventListener("touchmove", this.mousemove, false);
+					document.removeEventListener("touchend", this.mouseup, false);
+				}
+
+				if(this.mousemove){
+					document.removeEventListener("mousemove", this.mousemove, false);
+				}
+				if(this.mouseup){
+					document.removeEventListener("mouseup", this.mouseup, false);
+				}
 
 				this.mousemove = this._mousemove.bind(this);
 				this.mouseup = this._mouseup.bind(this);


### PR DESCRIPTION
If you press one mouse button and then another without releasing the first one, two mouseup (and mousemove) events are added to document. When you release both buttons, document.removeEventListener is trying to remove this.mouseup from document mouseup events array, but it can find just the newer one and not the old one, so the slider remains in a pressed state.
