### PR TITLE
Tooltip position in firefox was not set

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -1154,7 +1154,14 @@
 				};
 			},
 			_css: function(elementRef, styleName, value) {
-				elementRef.style[styleName] = value;
+                if ($) {
+                    $.style(elementRef, styleName, value);
+                } else {
+                    var style = styleName.replace(/^-ms-/, "ms-").replace(/-([\da-z])/gi, function (all, letter) {
+                        return letter.toUpperCase();
+                    });
+                    elementRef.style[style] = value;
+                }
 			}
 		};
 


### PR DESCRIPTION
Tooltip position in firefox was not set correctly (http://i.imgur.com/QPWkcOr.png), because firefox requires "marginLeft" property instead of "margin-left". So it's better to use jQuery method of setting styles if possible. Otherwise it can be simply converted.
