### PR TITLE
Fix range-slider bug (index.html Example 2) where hidden but touchable tooltip-max moves up too high.

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,10 @@
 		#R, #G, #B {
 			width: 300px;
 		}
+
+        .tooltip {
+            opacity: 1 !important;
+        }
     </style>
 	<script type='text/javascript' src="bower_components/modernizr/modernizr.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/index.html
+++ b/index.html
@@ -138,10 +138,6 @@
 		#R, #G, #B {
 			width: 300px;
 		}
-
-        .tooltip {
-            opacity: 1 !important;
-        }
     </style>
 	<script type='text/javascript' src="bower_components/modernizr/modernizr.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -756,7 +756,7 @@
 			        } else {
 			            this._removeClass(this.tooltip_max, 'bottom');
 			            this._addClass(this.tooltip_max, 'top');
-			            this.tooltip_max.style.top = -30 + 'px';
+			            this.tooltip_max.style.top = this.tooltip_min.style.top;
 			        }
 	 			}
 


### PR DESCRIPTION
![tooltip-max-bug](https://cloud.githubusercontent.com/assets/138476/4769027/db36e724-5b73-11e4-9c02-27ccf6f1b284.png)

Above image is bug-reproducing-demo from e4ec897 which I just set `tooltip.opacity=1` forcefully.

In current version, these tooltips are draggable **even when they are invisible**.
I think it is OK for `tooltip-main (center)` and `tooltip-min` to be draggable on hidden because they are very near slider UI, but not torelable for `tootip-MAX`, so I fixed `tootip-MAX`'s top position.