### PR TITLE
Fix bug where bootstrap-slider would fail to install when used as a dependency of another npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Slider view component for Twitter Bootstrap.",
   "main": "js/bootstrap-slider.js",
   "scripts": {
-    "install": "bower install",
+    "prepublish": "bower install",
     "test": "grunt test"
   },
   "repository": {


### PR DESCRIPTION
This commit fixes a bug where bootstrap-slider would fail to install when it was installed as part of a dependency of another module. It does this by changing `package.json` to move the `bower install` command from the `install` script to the `prepublish` script.

The root cause of the bug was that bower is listed in `devDependencies`, not the standard `dependencies` (this is the recommended setup, and correct here.) But this meant that bower is only installed when the user directly installs this script by running `npm install bootstrap-slider` or running `npm install` in the bootstrap-slider directory. Bower is _not_ installed when bootstrap-slider is listed as a dependency of another npm module and automatically installed by npm when installing that other module.

The problem is that `install` npm script is executed regardless of whether this module is installed directly or as a dependency. So the install script would try to run `bower install`, but bower would not be installed, and the install of bootstrap-slider would fail.

Moving `bower install` to the `prepublish` script is best practice according to the [npm docs](https://www.npmjs.org/doc/misc/npm-scripts.html). This means `bower install` will be executed before this script is published to npm via the `npm publish` command. It will also be run when executing `npm install` (with no arguments) in the bootstrap-slider directory.

Since the compiled .js file is already included in the repo by default, this shouldn't change any other behavior.
