### PR TITLE
ensuring that clicking on the slider triggers the slide event

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -896,7 +896,7 @@
 				this._trigger('slideStart', newValue);
 
 				this._setDataVal(newValue);
-				this.setValue(newValue);
+				this.setValue(newValue, true);
 
 				this._pauseEvent(ev);
 


### PR DESCRIPTION
right now, the slider doesn't fire the event if you click instead of drag
