### PR TITLE
Added a public layout function (a proxy), relayout, to re-render tooltip...

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ __NOTE:__ Optional parameters are italicized.
 | getAttribute | attribute | Get the slider's [attributes](#options) |
 | refresh | --- | Refreshes the current slider |
 | on | eventType, callback | When the slider event _eventType_ is triggered, the callback function will be invoked |
+| relayout | --- | Renders the tooltip again, after initialization. Useful in situations when the slider and tooltip are initially hidden. |
 
 Events
 ======

--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -694,6 +694,11 @@
 				return this;
 			},
 
+			relayout: function() {
+				this._layout();
+				return this;
+			},
+
 			/******************************+
 
 						HELPERS


### PR DESCRIPTION
.... Just added a public function `relayout` which calls the private `_layout`, to render the tooltip again. Think this helps in keeping the interface consistent. Addresses situations like in issue: https://github.com/seiyria/bootstrap-slider/issues/253 .