### PR TITLE
Prevents tooltip from blocking other interactions

### DIFF
--- a/less/bootstrap-slider.less
+++ b/less/bootstrap-slider.less
@@ -101,6 +101,7 @@
 		display: none;
 	}
 	.tooltip {
+		pointer-events: none; // prevent tooltip from blocking other targets
 		&.top {
 			margin-top: -36px;
 		}

--- a/sass/slider.scss
+++ b/sass/slider.scss
@@ -89,6 +89,9 @@ $baseBorderRadius: 4px;
   input {
     display: none;
   }
+  input {
+    pointer-events: none; // prevent tooltip from blocking other targets
+  }
   .tooltip-inner {
     white-space: nowrap;
   }


### PR DESCRIPTION
Adds `pointer-events: none` to the tooltip to prevent the tooltip from blocking other interactions, as seen here: 

**Original behavior (can't drag slider due to tooltip from slider below)**
![tooltip](https://cloud.githubusercontent.com/assets/848347/5574442/215fb864-8f74-11e4-9153-c2d5783c9b30.gif)
**New behavior (tooltip doesn't appear until hovering over slider, solving issue)**
![tooltip2](https://cloud.githubusercontent.com/assets/848347/5574469/ab95e3be-8f74-11e4-9ddd-d90a847d78d0.gif)
