### PR TITLE
fix: js-accessible value was not changed by slider function

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -1098,6 +1098,7 @@
 				var value = "value: '" + val + "'";
 				this.element.setAttribute('data', value);
 				this.element.setAttribute('value', val);
+                this.element.value = val;
 			},
 			_trigger: function(evt, val) {
 				val = (val || val === 0) ? val : undefined;


### PR DESCRIPTION
The .value property of the element was not changed by the _setDataVal function. Therefore it was not possible to get the correct input's value by accessing the element.