### PR TITLE
Fix for issue #286: Accounts for translate css transform in _offset function

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -1170,10 +1170,17 @@
 			_offset: function (obj) {
 				var ol = 0;
 				var ot = 0;
+				var tr, mat;
 				if (obj.offsetParent) {
 					do {
-					  ol += obj.offsetLeft;
-					  ot += obj.offsetTop;
+						ol += obj.offsetLeft;
+						ot += obj.offsetTop;
+						tr = $(obj).css("transform");
+						if (tr !== "none"){
+							mat = tr.substr(7, tr.length - 8).split(",");
+							ol += parseInt( mat[4], 10 );
+							ot += parseInt( mat[5], 10 );
+						}
 					} while (obj = obj.offsetParent);
 				}
 				return {


### PR DESCRIPTION
Fixes issue #286. Adds translate css transform component in parent offset computation in _offset method. This particularily solves issues when using both iScroll and bootstrap-sliders as iscroll use css transforms to move scrollables around.