### PR TITLE
Add left/top and right/bottom track segments so they can be styled independently

### DIFF
--- a/css/bootstrap-slider.css
+++ b/css/bootstrap-slider.css
@@ -39,7 +39,9 @@
   top: 50%;
   left: 0;
 }
-.slider.slider-horizontal .slider-selection {
+.slider.slider-horizontal .slider-selection,
+.slider.slider-horizontal .slider-track-left,
+.slider.slider-horizontal .slider-track-right {
   height: 100%;
   top: 0;
   bottom: 0;
@@ -71,6 +73,12 @@
   left: 0;
   top: 0;
   bottom: 0;
+}
+.slider.slider-vertical .slider-track-left,
+.slider.slider-vertical .slider-track-right {
+  width: 100%;
+  left: 0;
+  right: 0;
 }
 .slider.slider-vertical .slider-handle {
   margin-left: -5px;
@@ -131,6 +139,15 @@
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff9f9f9', endColorstr='#fff5f5f5', GradientType=0);
   -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
   box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  border-radius: 4px;
+}
+.slider-track-left,
+.slider-track-right {
+  position: absolute;
+  background: transparent;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;

--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -228,6 +228,7 @@
 			var updateSlider = false;
 			var parent = this.element.parentNode;
 			var sliderTrackSelection;
+			var sliderTrackLeft, sliderTrackRight;
 			var sliderMinHandle;
 			var sliderMaxHandle;
 
@@ -242,8 +243,14 @@
 				var sliderTrack = document.createElement("div");
 				sliderTrack.className = "slider-track";
 
+				sliderTrackLeft = document.createElement("div");
+				sliderTrackLeft.className = "slider-track-left";
+
 				sliderTrackSelection = document.createElement("div");
 				sliderTrackSelection.className = "slider-selection";
+
+				sliderTrackRight = document.createElement("div");
+				sliderTrackRight.className = "slider-track-right";
 
 				sliderMinHandle = document.createElement("div");
 				sliderMinHandle.className = "slider-handle min-slider-handle";
@@ -251,7 +258,9 @@
 				sliderMaxHandle = document.createElement("div");
 				sliderMaxHandle.className = "slider-handle max-slider-handle";
 
+				sliderTrack.appendChild(sliderTrackLeft);
 				sliderTrack.appendChild(sliderTrackSelection);
+				sliderTrack.appendChild(sliderTrackRight);
 				sliderTrack.appendChild(sliderMinHandle);
 				sliderTrack.appendChild(sliderMaxHandle);
 
@@ -364,7 +373,9 @@
 
 				// Undo existing inline styles for track
 				["left", "top", "width", "height"].forEach(function(prop) {
+					this._removeProperty(this.trackLeft, prop);
 					this._removeProperty(this.trackSelection, prop);
+					this._removeProperty(this.trackRight, prop);
 				}, this);
 
 				// Undo inline styles on handles
@@ -426,9 +437,14 @@
 				this.options.value = [this.options.value, this.options.max];
 			}
 
+			this.trackLeft = sliderTrackLeft || this.trackLeft;
 			this.trackSelection = sliderTrackSelection || this.trackSelection;
+			this.trackRight = sliderTrackRight || this.trackRight;
+
 			if (this.options.selection === 'none') {
+				this._addClass(this.trackLeft, 'hide');
 				this._addClass(this.trackSelection, 'hide');
+				this._addClass(this.trackRight, 'hide');
 			}
 
 			this.handle1 = sliderMinHandle || this.handle1;
@@ -769,11 +785,23 @@
 				this.handle2.style[this.stylePos] = positionPercentages[1]+'%';
 
 				if (this.options.orientation === 'vertical') {
+					this.trackLeft.style.top = '0';
+					this.trackLeft.style.height = Math.min(positionPercentages[0], positionPercentages[1]) +'%';
+
 					this.trackSelection.style.top = Math.min(positionPercentages[0], positionPercentages[1]) +'%';
 					this.trackSelection.style.height = Math.abs(positionPercentages[0] - positionPercentages[1]) +'%';
+
+					this.trackRight.style.bottom = '0';
+					this.trackRight.style.height = (100 - Math.min(positionPercentages[0], positionPercentages[1]) - Math.abs(positionPercentages[0] - positionPercentages[1])) +'%';
 				} else {
+					this.trackLeft.style.left = '0';
+					this.trackLeft.style.width = Math.min(positionPercentages[0], positionPercentages[1]) +'%';
+
 					this.trackSelection.style.left = Math.min(positionPercentages[0], positionPercentages[1]) +'%';
 					this.trackSelection.style.width = Math.abs(positionPercentages[0] - positionPercentages[1]) +'%';
+
+					this.trackRight.style.right = '0';
+					this.trackRight.style.width = (100 - Math.min(positionPercentages[0], positionPercentages[1]) - Math.abs(positionPercentages[0] - positionPercentages[1])) +'%';
 
 			        var offset_min = this.tooltip_min.getBoundingClientRect();
 			        var offset_max = this.tooltip_max.getBoundingClientRect();

--- a/less/bootstrap-slider.less
+++ b/less/bootstrap-slider.less
@@ -43,7 +43,7 @@
 			top: 50%;
 			left: 0;
 		}
-		.slider-selection {
+		.slider-selection, .slider-track-left, .slider-track-right {
 			height: 100%;
 			top: 0;
 			bottom: 0;
@@ -75,6 +75,11 @@
 			left: 0;
 			top: 0;
 			bottom: 0;
+		}
+		.slider-track-left, .slider-track-right {
+			width: 100%;
+			left: 0;
+			right: 0;
 		}
 		.slider-handle {
 			margin-left: (-@slider-line-height/4);
@@ -123,6 +128,14 @@
 	position: absolute;
 	#gradient > .vertical(#f9f9f9, #f5f5f5);
 	.box-shadow(inset 0 -1px 0 rgba(0,0,0,.15));
+	.box-sizing(border-box);
+	border-radius: @border-radius-base;
+}
+.slider-track-left, .slider-track-right {
+	position: absolute;
+	background: transparent;
+	//#gradient > .vertical(#c9c9c9, #c5c5c5);
+	//.box-shadow(inset 0 -1px 0 rgba(0,0,0,.15));
 	.box-sizing(border-box);
 	border-radius: @border-radius-base;
 }

--- a/less/bootstrap-slider.less
+++ b/less/bootstrap-slider.less
@@ -134,8 +134,6 @@
 .slider-track-left, .slider-track-right {
 	position: absolute;
 	background: transparent;
-	//#gradient > .vertical(#c9c9c9, #c5c5c5);
-	//.box-shadow(inset 0 -1px 0 rgba(0,0,0,.15));
 	.box-sizing(border-box);
 	border-radius: @border-radius-base;
 }

--- a/sass/slider.scss
+++ b/sass/slider.scss
@@ -41,7 +41,7 @@ $baseBorderRadius: 4px;
       top:  50%;
       left: 0;
     }
-    .slider-selection {
+    .slider-selection, .slider-track-left, .slider-track-right {
       height: 100%;
       top: 0;
       bottom: 0;
@@ -74,6 +74,11 @@ $baseBorderRadius: 4px;
       top: 0;
       bottom: 0;
     }
+	.slider-track-left, .slider-track-right {
+	  width: 100%;
+	  left: 0;
+	  right: 0;
+	}
     .slider-handle {
       margin-left: -$baseLineHeight/4;
       margin-top: -$baseLineHeight/2;
@@ -108,6 +113,13 @@ $baseBorderRadius: 4px;
   	@include box-shadow(inset 0 -1px 0 rgba(0,0,0,0.15));
   	@include box-sizing(border-box);
 	@include border-radius($baseBorderRadius);
+}
+
+.slider-track-left, .slider-track-right {
+  position: absolute;
+  background: transparent;
+  .box-sizing(border-box);
+  border-radius: border-radius($baseBorderRadius);
 }
 
 .slider-handle {

--- a/test/specs/LeftAndRightTrackSpec.js
+++ b/test/specs/LeftAndRightTrackSpec.js
@@ -1,0 +1,224 @@
+/*
+	**********************
+
+	Left/Right Track Tests
+
+	**********************
+
+	This spec has tests for checking that the widths of the left and right
+	segments are the correct widths and colors, based on their CSS.
+ */
+describe("Left/Right Track Tests", function() {
+
+	var unstyledID = "left-right-slider";
+	var styledID = "left-right-slider-styled";
+
+	var testSlider;
+
+	describe("Single-value sliders, no styling", function() {
+
+		var id = unstyledID;
+
+		beforeEach(function() {
+			testSlider = $("#testSlider1").slider({
+				id: id,
+				min: 0,
+				max: 10,
+				value: 5
+			});
+		});
+
+		it("left width is zero", function()
+		{
+			var leftTrack = $("#" + id + " .slider-track-left");
+			expect($(leftTrack).css("width")).toBe("0px");
+		});
+
+		it("right segment width is 50%", function()
+		{
+			var rightTrack = $("#" + id + " .slider-track-right");
+			var trackWidth = rightTrack.parent().width();
+			expect($(rightTrack).css("width")).toBe((trackWidth / 2) + "px");
+		});
+
+		it("right segment is transparent", function()
+		{
+			var rightTrack = $("#" + id + " .slider-track-right");
+			var rightColor = rightTrack.css("background-color");
+			var isTransparent = rightColor.match(/rgba\([0-9]{1,3}, [0-9]{1,3}, [0-9]{1,3}, 0\)/);
+			expect(isTransparent).toBeTruthy();
+		})
+
+		afterEach(function() {
+			if(testSlider) {
+				testSlider.slider('destroy');
+				testSlider = null;
+			}
+		})
+	});
+
+	describe("Single-value sliders, with styling", function() {
+
+		var id = styledID;
+
+		beforeEach(function() {
+			testSlider = $("#testSlider1").slider({
+				id: id,
+				min: 0,
+				max: 10,
+				value: 5
+			});
+		});
+
+		it("left width is zero", function()
+		{
+			var leftTrack = $("#" + id + " .slider-track-left");
+			expect($(leftTrack).css("width")).toBe("0px");
+		});
+
+		it("right segment width is 50%", function()
+		{
+			var rightTrack = $("#" + id + " .slider-track-right");
+			var trackWidth = rightTrack.parent().width();
+			expect($(rightTrack).css("width")).toBe((trackWidth / 2) + "px");
+		});
+
+		it("right segment is red", function()
+		{
+			var rightTrack = $("#" + id + " .slider-track-right");
+			var rightColor = rightTrack.css("background-color");
+			expect(rightColor).toBe("rgb(255, 0, 0)");
+		})
+
+		afterEach(function() {
+			if(testSlider) {
+				testSlider.slider('destroy');
+				testSlider = null;
+			}
+		})
+	});
+
+	describe("Range sliders, no styling", function() {
+
+		var id = unstyledID;
+		var values = {
+			min: 0,
+			max: 10,
+			values: [ 4, 6 ]
+		};
+
+		beforeEach(function() {
+			testSlider = $("#testSlider1").slider({
+				id: id,
+				min: values.min,
+				max: values.max,
+				range: true,
+				value: values.values
+			});
+		});
+
+		it("left width is zero", function()
+		{
+			var leftTrack = $("#" + id + " .slider-track-left");
+
+			var trackWidth = leftTrack.parent().width();
+			var expectedWidth = ((values.values[0] - values.min) / (values.max - values.min)) * trackWidth;
+
+			expect($(leftTrack).css("width")).toBe(expectedWidth + "px");
+		});
+
+		it("right segment width is 50%", function()
+		{
+			var rightTrack = $("#" + id + " .slider-track-right");
+			var trackWidth = rightTrack.parent().width();
+
+			var expectedWidth = ((values.max - values.values[1]) / (values.max - values.min)) * trackWidth;
+
+			expect($(rightTrack).css("width")).toBe(expectedWidth + "px");
+		});
+
+		it("left segment is transparent", function()
+		{
+			var leftTrack = $("#" + id + " .slider-track-left");
+			var leftColor = leftTrack.css("background-color");
+			var isTransparent = leftColor.match(/rgba\([0-9]{1,3}, [0-9]{1,3}, [0-9]{1,3}, 0\)/);
+			expect(isTransparent).toBeTruthy();
+		})
+
+		it("right segment is transparent", function()
+		{
+			var rightTrack = $("#" + id + " .slider-track-right");
+			var rightColor = rightTrack.css("background-color");
+			var isTransparent = rightColor.match(/rgba\([0-9]{1,3}, [0-9]{1,3}, [0-9]{1,3}, 0\)/);
+			expect(isTransparent).toBeTruthy();
+		})
+
+		afterEach(function() {
+			if(testSlider) {
+				testSlider.slider('destroy');
+				testSlider = null;
+			}
+		})
+	});
+
+	describe("Range sliders, with styling", function() {
+
+		var id = styledID;
+		var values = {
+			min: 0,
+			max: 10,
+			values: [ 4, 6 ]
+		};
+
+		beforeEach(function() {
+			testSlider = $("#testSlider1").slider({
+				id: id,
+				min: values.min,
+				max: values.max,
+				range: true,
+				value: values.values
+			});
+		});
+
+		it("left width is zero", function()
+		{
+			var leftTrack = $("#" + id + " .slider-track-left");
+
+			var trackWidth = leftTrack.parent().width();
+			var expectedWidth = ((values.values[0] - values.min) / (values.max - values.min)) * trackWidth;
+
+			expect($(leftTrack).css("width")).toBe(expectedWidth + "px");
+		});
+
+		it("right segment width is 50%", function()
+		{
+			var rightTrack = $("#" + id + " .slider-track-right");
+			var trackWidth = rightTrack.parent().width();
+
+			var expectedWidth = ((values.max - values.values[1]) / (values.max - values.min)) * trackWidth;
+
+			expect($(rightTrack).css("width")).toBe(expectedWidth + "px");
+		});
+
+		it("left segment is green", function()
+		{
+			var leftTrack = $("#" + id + " .slider-track-left");
+			var leftColor = leftTrack.css("background-color");
+			expect(leftColor).toBe("rgb(0, 255, 0)");
+		})
+
+		it("right segment is red", function()
+		{
+			var rightTrack = $("#" + id + " .slider-track-right");
+			var rightColor = rightTrack.css("background-color");
+			expect(rightColor).toBe("rgb(255, 0, 0)");
+		})
+
+		afterEach(function() {
+			if(testSlider) {
+				testSlider.slider('destroy');
+				testSlider = null;
+			}
+		})
+	});
+});

--- a/test/specs/LeftAndRightTrackSpec.js
+++ b/test/specs/LeftAndRightTrackSpec.js
@@ -47,14 +47,14 @@ describe("Left/Right Track Tests", function() {
 			var rightColor = rightTrack.css("background-color");
 			var isTransparent = rightColor.match(/rgba\([0-9]{1,3}, [0-9]{1,3}, [0-9]{1,3}, 0\)/);
 			expect(isTransparent).toBeTruthy();
-		})
+		});
 
 		afterEach(function() {
 			if(testSlider) {
 				testSlider.slider('destroy');
 				testSlider = null;
 			}
-		})
+		});
 	});
 
 	describe("Single-value sliders, with styling", function() {
@@ -88,14 +88,14 @@ describe("Left/Right Track Tests", function() {
 			var rightTrack = $("#" + id + " .slider-track-right");
 			var rightColor = rightTrack.css("background-color");
 			expect(rightColor).toBe("rgb(255, 0, 0)");
-		})
+		});
 
 		afterEach(function() {
 			if(testSlider) {
 				testSlider.slider('destroy');
 				testSlider = null;
 			}
-		})
+		});
 	});
 
 	describe("Range sliders, no styling", function() {
@@ -143,7 +143,7 @@ describe("Left/Right Track Tests", function() {
 			var leftColor = leftTrack.css("background-color");
 			var isTransparent = leftColor.match(/rgba\([0-9]{1,3}, [0-9]{1,3}, [0-9]{1,3}, 0\)/);
 			expect(isTransparent).toBeTruthy();
-		})
+		});
 
 		it("right segment is transparent", function()
 		{
@@ -151,14 +151,14 @@ describe("Left/Right Track Tests", function() {
 			var rightColor = rightTrack.css("background-color");
 			var isTransparent = rightColor.match(/rgba\([0-9]{1,3}, [0-9]{1,3}, [0-9]{1,3}, 0\)/);
 			expect(isTransparent).toBeTruthy();
-		})
+		});
 
 		afterEach(function() {
 			if(testSlider) {
 				testSlider.slider('destroy');
 				testSlider = null;
 			}
-		})
+		});
 	});
 
 	describe("Range sliders, with styling", function() {
@@ -205,20 +205,20 @@ describe("Left/Right Track Tests", function() {
 			var leftTrack = $("#" + id + " .slider-track-left");
 			var leftColor = leftTrack.css("background-color");
 			expect(leftColor).toBe("rgb(0, 255, 0)");
-		})
+		});
 
 		it("right segment is red", function()
 		{
 			var rightTrack = $("#" + id + " .slider-track-right");
 			var rightColor = rightTrack.css("background-color");
 			expect(rightColor).toBe("rgb(255, 0, 0)");
-		})
+		});
 
 		afterEach(function() {
 			if(testSlider) {
 				testSlider.slider('destroy');
 				testSlider = null;
 			}
-		})
+		});
 	});
 });

--- a/tpl/SpecRunner.tpl
+++ b/tpl/SpecRunner.tpl
@@ -6,6 +6,17 @@
 <% css.forEach(function(style){ %>
   <link rel="stylesheet" type="text/css" href="<%= style %>">
 <% }) %>
+	<style type="text/css">
+		#left-right-slider-styled .slider-track-left
+		{
+			background: rgb(0, 255, 0);
+		}
+
+		#left-right-slider-styled .slider-track-right
+		{
+			background: rgb(255, 0, 0);
+		}
+	</style>
 </head>
 <body>
 	<input id="testSliderGeneric" type="text"/>

--- a/tpl/index.tpl
+++ b/tpl/index.tpl
@@ -104,6 +104,19 @@
 		#ex6SliderVal {
 			color: green;
 		}
+
+		#slider12a .slider-track-right, #slider12c .slider-track-right {
+			background: green;
+		}
+
+		#slider12b .slider-track-left, #slider12c .slider-track-left {
+			background: red;
+		}
+
+		#slider12c .slider-selection {
+			background: yellow;
+		}
+
     </style>
 
     <style type='text/css'>
@@ -598,10 +611,76 @@ var slider = new Slider("#ex11", {
 });
 
       </code></pre>
-  </div> 
+  </div>
 
 
-      </div> <!-- /examples -->
+  <div class='slider-example'>
+    <h3>Example 12:</h3>
+    <p>Coloring the left and right track segments.</p>
+	<div class="well">
+      Single-value slider, right track:<br/>
+      <input id="ex12a" type="text"/><br/>
+      Note that there is no left track on the single-value slider.  The
+      area to the left of the handle is the selection.
+      <br/><br/>
+      Range slider, left track:<br/>
+      <input id="ex12b" type="text"/>
+      <br/><br/>
+      Range slider, left and right tracks, and selection:<br/>
+      <input id="ex12c" type="text"/>
+    </div>
+    <pre><code>
+###################
+HTML
+###################
+
+Single-value slider, right track:
+&ltinput id="ex12a" type="text"/&gt&ltbr/&gt
+Note that there is no left track on the single-value slider. The area to the left of the handle is the selection.
+
+Range slider, left track:
+&ltinput id="ex12b" type="text"/&gt&ltbr/&gt
+
+
+Range slider, left and right tracks, and selection:
+&ltinput id="ex12c" type="text"/&gt&ltbr/&gt
+
+###################
+JavaScript
+###################
+
+// With JQuery
+$("#ex12a").slider({ id: "slider12a", min: 0, max: 10, value: 5 });
+$("#ex12b").slider({ id: "slider12a", min: 0, max: 10, range: true, value: [3, 7] });
+$("#ex12c").slider({ id: "slider12a", min: 0, max: 10, range: true, value: [3, 7] });
+
+// Without JQuery
+new Slider("#ex12a", { id: "slider12a", min: 0, max: 10, value: 5 });
+new Slider("#ex12b", { id: "slider12a", min: 0, max: 10, range: true, value: [3, 7] });
+new Slider("#ex12c", { id: "slider12a", min: 0, max: 10, range: true, value: [3, 7] });
+
+###################
+CSS
+###################
+
+#slider12a .slider-track-right, #slider12c .slider-track-right {
+	background: green;
+}
+
+#slider12b .slider-track-left, #slider12c .slider-track-left {
+	background: red;
+}
+
+#slider12c .slider-selection {
+	background: yellow;
+}
+
+
+		</code></pre>
+  </div>
+
+
+	  </div> <!-- /examples -->
     </div> <!-- /container -->
 
 
@@ -684,6 +763,28 @@ var slider = new Slider("#ex11", {
 		        min: 0,
 		        max: 200000
 	      	});
+
+			/* Example 12 */
+			$("#ex12a").slider({
+				id: "slider12a",
+				min: 0,
+				max: 10,
+				value: 5
+            });
+			$("#ex12b").slider({
+				id: "slider12b",
+				min: 0,
+				max: 10,
+				range: true,
+				value: [ 3, 7 ]
+			});
+			$("#ex12c").slider({
+				id: "slider12c",
+				min: 0,
+				max: 10,
+				range: true,
+				value: [ 3, 7 ]
+			});
     	});
     </script>
     <!-- Placed at the end of the document so the pages load faster -->

--- a/tpl/index.tpl
+++ b/tpl/index.tpl
@@ -651,13 +651,13 @@ JavaScript
 
 // With JQuery
 $("#ex12a").slider({ id: "slider12a", min: 0, max: 10, value: 5 });
-$("#ex12b").slider({ id: "slider12a", min: 0, max: 10, range: true, value: [3, 7] });
-$("#ex12c").slider({ id: "slider12a", min: 0, max: 10, range: true, value: [3, 7] });
+$("#ex12b").slider({ id: "slider12b", min: 0, max: 10, range: true, value: [3, 7] });
+$("#ex12c").slider({ id: "slider12c", min: 0, max: 10, range: true, value: [3, 7] });
 
 // Without JQuery
 new Slider("#ex12a", { id: "slider12a", min: 0, max: 10, value: 5 });
-new Slider("#ex12b", { id: "slider12a", min: 0, max: 10, range: true, value: [3, 7] });
-new Slider("#ex12c", { id: "slider12a", min: 0, max: 10, range: true, value: [3, 7] });
+new Slider("#ex12b", { id: "slider12b", min: 0, max: 10, range: true, value: [3, 7] });
+new Slider("#ex12c", { id: "slider12c", min: 0, max: 10, range: true, value: [3, 7] });
 
 ###################
 CSS


### PR DESCRIPTION
This adds left and right track segments that can be targeted by CSS (with .slider-track-left and .slider-track-right, respectively).  It allows users to style the "unselected" part of the slider, which is useful if you're building a "red-amber-green" style slider.

jsfiddle: http://jsfiddle.net/qfjjv2vp/