### PR TITLE
Add support for tooltip_separator option.

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,7 +371,7 @@ $("#ex5").slider();
 var slider = new Slider('#ex5');
 
 $("#destroyEx5Slider").click(function() {
-	
+
 	// With JQuery
 	$("#ex5").slider('destroy');
 
@@ -598,7 +598,7 @@ var slider = new Slider("#ex11", {
 });
 
       </code></pre>
-  </div> 
+  </div>
 
 
       </div> <!-- /examples -->
@@ -672,7 +672,7 @@ var slider = new Slider("#ex11", {
 			/* Example 9 */
 			$("#ex9").slider({
 				precision: 2,
-				value: 8.115 
+				value: 8.115
 			});
 
 	      	/* Example 10 */

--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -531,9 +531,11 @@
 				handle: 'round',
 				reversed: false,
 				enabled: true,
-				formatter: function(val) {
+				tooltip_separator: ' : ',
+				formatter: function(val, sep) {
+					sep = sep || ' : ';
 					if(val instanceof Array) {
-						return val[0] + " : " + val[1];
+						return val[0] + sep + val[1];
 					} else {
 						return val;
 					}
@@ -792,7 +794,7 @@
 	 			var formattedTooltipVal;
 
 				if (this.options.range) {
-					formattedTooltipVal = this.options.formatter(this.options.value);
+					formattedTooltipVal = this.options.formatter(this.options.value, this.options['tooltip_separator']);
 					this._setText(this.tooltipInner, formattedTooltipVal);
 					this.tooltip.style[this.stylePos] = (positionPercentages[1] + positionPercentages[0])/2 + '%';
 
@@ -808,10 +810,10 @@
 						this._css(this.tooltip, 'margin-left', -this.tooltip.offsetWidth / 2 + 'px');
 					}
 
-					var innerTooltipMinText = this.options.formatter(this.options.value[0]);
+					var innerTooltipMinText = this.options.formatter(this.options.value[0], this.options['tooltip_separator']);
 					this._setText(this.tooltipInner_min, innerTooltipMinText);
 
-					var innerTooltipMaxText = this.options.formatter(this.options.value[1]);
+					var innerTooltipMaxText = this.options.formatter(this.options.value[1], this.options['tooltip_separator']);
 					this._setText(this.tooltipInner_max, innerTooltipMaxText);
 
 					this.tooltip_min.style[this.stylePos] = positionPercentages[0] + '%';
@@ -830,7 +832,7 @@
 						this._css(this.tooltip_max, 'margin-left', -this.tooltip_max.offsetWidth / 2 + 'px');
 					}
 				} else {
-					formattedTooltipVal = this.options.formatter(this.options.value[0]);
+					formattedTooltipVal = this.options.formatter(this.options.value[0], this.options['tooltip_separator']);
 					this._setText(this.tooltipInner, formattedTooltipVal);
 
 					this.tooltip.style[this.stylePos] = positionPercentages[0] + '%';

--- a/test/specs/ConflictingOptionsSpec.js
+++ b/test/specs/ConflictingOptionsSpec.js
@@ -1,6 +1,6 @@
-/*	
+/*
 	*************************
-	
+
 	Conflicting Options Tests
 
 	*************************
@@ -8,9 +8,9 @@
 	This spec has tests for checking if two or more options do not conflict with one another
 	As option conflicts are reported and resolved, write tests for them here.
 	This will help ensure that they are accounted for and do not arise again.
-*/	
+*/
 describe("Conflicting Options Tests", function() {
-	
+
 	var testSlider;
 
 	it("Should have the value zero when it is slided to zero", function() {
@@ -40,6 +40,22 @@ describe("Conflicting Options Tests", function() {
 		var value = testSlider.slider("getValue");
 		// Run tests
 		expect(value).toBe(8.12);
+	});
+
+
+	it("Should take into account the value of the `tooltip_separator` option", function() {
+		// Create Slider
+		testSlider = $("#testSlider1").slider({
+			min: 0,
+			value: [25, 50],
+			max: 100,
+			'tooltip_split': false,
+			'tooltip_separator': ' test '
+		});
+		// Retrieve tooltip content
+		var content = testSlider.siblings('.slider').find('.tooltip-main .tooltip-inner').html();
+		// Run tests
+		expect(content).toBe('25 test 50');
 	});
 
 	afterEach(function() {


### PR DESCRIPTION
Despite the fact that this option is mentioned in the documentation, I could not find it being implemented in any way in the codebase, so I did.

The implementation is poor as it changes the method signature for `formatter`. I did however write a basic test which should pass.

Let me know what else I should change, and I'll update my PR accordingly.