### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ Options can be passed either as a data (data-slider-foo) attribute, or as part o
 | range |	bool |	false	| make range slider. Optional if initial value is an array. If initial value is scalar, max will be used for second value. |
 | selection |	string |	'before' |	selection placement. Accepts: 'before', 'after' or 'none'. In case of a range slider, the selection will be placed between the handles |
 | tooltip |	string |	'show' |	whether to show the tooltip on drag, hide the tooltip, or always show the tooltip. Accepts: 'show', 'hide', or 'always' |
-| tooltip_separator |	string |	':' |	tooltip separator |
 | tooltip_split |	bool |	false |	if false show one tootip if true show two tooltips one for each handler |
 | handle |	string |	'round' |	handle shape. Accepts: 'round', 'square', 'triangle' or 'custom' |
 | reversed | bool | false | whether or not the slider should be reversed |


### PR DESCRIPTION
Reflects the lack of the `tooltip_separator` option, as discussed in https://github.com/seiyria/bootstrap-slider/pull/300.