### PR TITLE
Calculated offsets incorrect when body has a margin of auto

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -1298,9 +1298,9 @@
 				element.className = newClasses.trim();
 			},
       _offset: function (obj) {
-        var rect = obj.getBoundingClientRect()
-          , ol = rect.left
-          , ot = rect.top;
+        var rect = obj.getBoundingClientRect(),
+          ol = rect.left,
+          ot = rect.top;
 
         return {
           left: ol,

--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -1297,20 +1297,16 @@
 
 				element.className = newClasses.trim();
 			},
-			_offset: function (obj) {
-				var ol = 0;
-				var ot = 0;
-				if (obj.offsetParent) {
-					do {
-					  ol += obj.offsetLeft;
-					  ot += obj.offsetTop;
-					} while (obj = obj.offsetParent);
-				}
-				return {
-					left: ol,
-					top: ot
-				};
-			},
+      _offset: function (obj) {
+        var rect = obj.getBoundingClientRect()
+          , ol = rect.left
+          , ot = rect.top;
+
+        return {
+          left: ol,
+          top: ot
+        };
+      },
 			_css: function(elementRef, styleName, value) {
                 if ($) {
                     $.style(elementRef, styleName, value);


### PR DESCRIPTION
Calculated slider offsets are incorrect when the body has a margin of auto - resulting in an offset in display when you initiate the drag and where the handle ends up being displayed. 

I've changed the do..while loop with offsetParent to use getBoundingClientRect() and it appears to fix the issue.

Broken Example: http://jsfiddle.net/0rh54yxo/1/
Working Example (using getBoundingClientRect): http://jsfiddle.net/0rh54yxo/6/
