### PR TITLE
Fix tick labels for some browsers

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -894,7 +894,7 @@
 					var minTickValue = Math.min.apply(Math, this.options.ticks);
 
 					var styleSize = this.options.orientation === 'vertical' ? 'height' : 'width';
-					var styleMargin = this.options.orientation === 'vertical' ? 'margin-top' : 'margin-left';
+					var styleMargin = this.options.orientation === 'vertical' ? 'marginTop' : 'marginLeft';
 					var labelSize = this.size / (this.options.ticks.length - 1);
 
 					if (this.tickLabelContainer) {


### PR DESCRIPTION
Use camelCase syntax for style names instead of separating words with
dash like in CSS. It works better in some non-bleeding-edge browsers,
for example Firefox ESR / Iceweasel (31.x.x).

The same syntax is used in _css() helper function replacement.