### PR TITLE
Fixed issue with touch-enabled laptops using a mouse

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -583,11 +583,11 @@
 				// Bind touch handlers
 				this.mousedown = this._mousedown.bind(this);
 				this.sliderElem.addEventListener("touchstart", this.mousedown, false);
-			} else {
-				// Bind mouse handlers
-				this.mousedown = this._mousedown.bind(this);
-				this.sliderElem.addEventListener("mousedown", this.mousedown, false);
 			}
+            // Bind mouse handlers
+            this.mousedown = this._mousedown.bind(this);
+            this.sliderElem.addEventListener("mousedown", this.mousedown, false);
+
 
 			// Bind tooltip-related handlers
 			if(this.options.tooltip === 'hide') {


### PR DESCRIPTION
This change fixes issues that appear when a user has a touch-enabled computer. The current implementation detects that the system is touch capable, but does not take into account that the user might be using a regular mouse instead of the touch screen.

fixes #293 
fixes #312 