### PR TITLE
Add focus option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Options can be passed either as a data (data-slider-foo) attribute, or as part o
 | ticks_labels | array | [ ] | Defines the labels below the tick marks. Accepts HTML input. |
 | ticks_snap_bounds | float | 0 | Used to define the snap bounds of a tick. Snaps to the tick if value is within these bounds. |
 | scale | string | 'linear' | Set to 'logarithmic' to use a logarithmic scale. |
+| focus | bool | false | Focus the appropriate slider handle after a value change. |
 
 Functions
 =========

--- a/index.html
+++ b/index.html
@@ -749,6 +749,45 @@ var slider = new Slider('#ex14', {
             </code></pre>
       	</div>
 
+      <div class="slider-example">
+        <h3>Example 15:</h3>
+        <p>Focus the slider handle after a value change.</p>
+        <div class="well">
+          Single-value slider:<br/>
+          <input id="ex15a" type="text"/><br/>
+          <br/><br/>
+          Range slider:<br/>
+          <input id="ex15b" type="text"/>
+        </div>
+        <pre>
+          <code>
+
+###################
+HTML
+###################
+&lt;!-- Single-value slider: --&gt;
+&ltinput id="ex15a" type="text"/&gt&ltbr/&gt
+
+&lt;!-- Range slider: --&gt;
+&ltinput id="ex15b" type="text"/&gt&ltbr/&gt
+Note that the slider handle that caused the value change is focused.
+
+###################
+JavaScript
+###################
+
+// With JQuery
+$("#ex15a").slider({ min: 0, max: 10, value: 0, focus: true });
+$("#ex15b").slider({ min: 0, max: 10, value: [0, 10], focus: true });
+
+// Without JQuery
+new Slider("#ex15a", { min: 0, max: 10, value: 0, focus: true });
+new Slider("#ex15b", { min: 0, max: 10, value: [0, 10], focus: true });
+
+          </code>
+        </pre>
+      </div>
+
 	  </div> <!-- /examples -->
     </div> <!-- /container -->
 
@@ -870,6 +909,20 @@ var slider = new Slider('#ex14', {
 				step: 10
 			});
     	});
+
+      /* Example 15 */
+      $("#ex15a").slider({
+        min  : 0,
+        max  : 10,
+        value: 0,
+        focus: true
+      });
+      $("#ex15b").slider({
+        min  : 0,
+        max  : 10,
+        value: [ 0, 10 ],
+        focus: true
+      });
     </script>
     <!-- Placed at the end of the document so the pages load faster -->
   </body>

--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -660,7 +660,8 @@
 				ticks: [],
 				ticks_labels: [],
 				ticks_snap_bounds: 0,
-				scale: 'linear'
+				scale: 'linear',
+				focus: false
 			},
 
 			over: false,
@@ -1014,8 +1015,6 @@
 					return false;
 				}
 
-				this._triggerFocusOnHandle();
-
 				this.offset = this._offset(this.sliderElem);
 				this.size = this.sliderElem[this.sizePos];
 
@@ -1065,6 +1064,10 @@
 				this.setValue(newValue);
 
 				this._pauseEvent(ev);
+
+				if (this.options.focus) {
+					this._triggerFocusOnHandle(this.dragged);
+				}
 
 				return true;
 			},

--- a/test/specs/FocusOptionSpec.js
+++ b/test/specs/FocusOptionSpec.js
@@ -20,7 +20,7 @@ describe("Focus Option Tests", function() {
     target.dispatchEvent(myEvent);
   };
 
-  it("should not be focused after value change when 'focus' is false", function() {
+  it("handle should not be focused after value change when 'focus' is false", function() {
     testSlider = $("#testSlider1").slider({
       min  : 0,
       max  : 10,

--- a/test/specs/FocusOptionSpec.js
+++ b/test/specs/FocusOptionSpec.js
@@ -1,0 +1,67 @@
+/*
+  ******************
+
+  Focus Option Tests
+
+  ******************
+
+  This spec has tests for checking proper behavior of the focus option.
+*/
+
+describe("Focus Option Tests", function() {
+
+  var testSlider;
+
+  var simulateMousedown = function(target, pos) {
+    var myEvent = document.createEvent("MouseEvents");
+    myEvent.initEvent("mousedown", true, true);
+    myEvent.pageX = pos;
+    myEvent.pageY = pos;
+    target.dispatchEvent(myEvent);
+  };
+
+  it("should not be focused after value change when 'focus' is false", function() {
+    testSlider = $("#testSlider1").slider({
+      min  : 0,
+      max  : 10,
+      value: 0,
+      focus: false,
+      id   : "testSlider"
+    });
+
+    var hasFocus;
+    $("#testSlider").find(".min-slider-handle").focus(function() {
+      hasFocus = true;
+    });
+
+    simulateMousedown($("#testSlider").find(".slider-track-high").get(0), 1000);
+
+    expect(hasFocus).toBe(undefined);
+  });
+
+  it("handle should be focused after value change when 'focus' is true", function() {
+    testSlider = $("#testSlider1").slider({
+      min  : 0,
+      max  : 10,
+      value: 0,
+      focus: true,
+      id   : "testSlider"
+    });
+
+    var hasFocus;
+    $("#testSlider").find(".min-slider-handle").focus(function() {
+      hasFocus = true;
+    });
+
+    simulateMousedown($("#testSlider").find(".slider-track-high").get(0), 1000);
+
+    expect(hasFocus).toBe(true);
+  });
+
+  afterEach(function() {
+    if (testSlider) {
+      testSlider.slider("destroy");
+      testSlider = null;
+    }
+  });
+});

--- a/tpl/index.tpl
+++ b/tpl/index.tpl
@@ -749,6 +749,45 @@ var slider = new Slider('#ex14', {
             </code></pre>
       	</div>
 
+      <div class="slider-example">
+        <h3>Example 15:</h3>
+        <p>Focus the slider handle after a value change.</p>
+        <div class="well">
+          Single-value slider:<br/>
+          <input id="ex15a" type="text"/><br/>
+          <br/><br/>
+          Range slider:<br/>
+          <input id="ex15b" type="text"/>
+        </div>
+        <pre>
+          <code>
+
+###################
+HTML
+###################
+&lt;!-- Single-value slider: --&gt;
+&ltinput id="ex15a" type="text"/&gt&ltbr/&gt
+
+&lt;!-- Range slider: --&gt;
+&ltinput id="ex15b" type="text"/&gt&ltbr/&gt
+Note that the slider handle that caused the value change is focused.
+
+###################
+JavaScript
+###################
+
+// With JQuery
+$("#ex15a").slider({ min: 0, max: 10, value: 0, focus: true });
+$("#ex15b").slider({ min: 0, max: 10, value: [0, 10], focus: true });
+
+// Without JQuery
+new Slider("#ex15a", { min: 0, max: 10, value: 0, focus: true });
+new Slider("#ex15b", { min: 0, max: 10, value: [0, 10], focus: true });
+
+          </code>
+        </pre>
+      </div>
+
 	  </div> <!-- /examples -->
     </div> <!-- /container -->
 
@@ -870,6 +909,20 @@ var slider = new Slider('#ex14', {
 				step: 10
 			});
     	});
+
+      /* Example 15 */
+      $("#ex15a").slider({
+        min  : 0,
+        max  : 10,
+        value: 0,
+        focus: true
+      });
+      $("#ex15b").slider({
+        min  : 0,
+        max  : 10,
+        value: [ 0, 10 ],
+        focus: true
+      });
     </script>
     <!-- Placed at the end of the document so the pages load faster -->
   </body>


### PR DESCRIPTION
I think the way ``_triggerFocusOnHandle()`` was used before (in ``_mousedown()``),
i.e. without any arguments, was unintended in the first place. Now, it is called with
the appropriate slider number after the value change took place if the ``focus``
option is ``true``.

Also updated docs and index template.
I don't think that a unit test is required here.

When this PR is accepted, #330 is fixed and can be closed.