### PR TITLE
Changed the order of the slideStop event, moved right after dataSetVal issue #369

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -1187,8 +1187,8 @@
 				this._setDataVal(val);
 				this.setValue(val, true, true);
 
-				this._trigger('slideStop', val);
 				this._setDataVal(val);
+				this._trigger('slideStop', val);
 				this._layout();
 
 				this._pauseEvent(ev);
@@ -1251,8 +1251,8 @@
 				var val = this._calculateValue(true);
 
 				this._layout();
-				this._trigger('slideStop', val);
 				this._setDataVal(val);
+				this._trigger('slideStop', val);
 
 				return false;
 			},


### PR DESCRIPTION
Small change to trigger the slideStop event after the setDataVal, instead of before.

This fixes the issue #369 