### PR TITLE
CSS Fix: vertical orientation in reverse(RTL) mode

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -938,7 +938,14 @@
 					var minTickValue = Math.min.apply(Math, this.options.ticks);
 
 					var styleSize = this.options.orientation === 'vertical' ? 'height' : 'width';
-					var styleMargin = this.options.orientation === 'vertical' ? 'marginTop' : 'marginLeft';
+					var styleMargin;
+                    if (this.options.orientation === 'vertical' ){
+                        styleMargin = 'marginTop';
+                    }else{
+                        styleMargin = 'marginLeft';
+                        if (this.options.reversed === true) styleMargin = 'marginRight';
+                    }
+                    
 					var labelSize = this.size / (this.options.ticks.length - 1);
 
 					if (this.tickLabelContainer) {


### PR DESCRIPTION
When slider work in *revered: true* mode and general orientation of page is RTL, ticker text has margin-left css property. To display it properly it should have margin-right. 