### PR TITLE
Make slider ticks 100% opaque.

### DIFF
--- a/css/bootstrap-slider.css
+++ b/css/bootstrap-slider.css
@@ -218,7 +218,7 @@
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   filter: none;
-  opacity: 0.8;
+  opacity: 1;
   border: 0px solid transparent;
 }
 .slider-tick.round {


### PR DESCRIPTION
Previously slider ticks were 80% opaque, on dark backgrounds the color dependency between the opaque track and semi-transparent ticks looks kinda weird.