### PR TITLE
Add style field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.1.1",
   "description": "Slider view component for Twitter Bootstrap.",
   "main": "js/bootstrap-slider.js",
+  "style": "dist/css/bootstrap-slider.css",
   "scripts": {
     "prepublish": "bower install",
     "postpublish": "sh ./scripts/postpublish.sh",


### PR DESCRIPTION
In order to use bootstrap-slider with tools like [Parcelify](https://github.com/rotundasoftware/parcelify) and [Sheetify](https://github.com/sheetify/sheetify), the `package.json` file needs a `style` field referring to the correct CSS file. Bootstrap itself, for example, already has this.