### PR TITLE
- fixes #439 : ticks are not reversed when reversed=true

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -1009,6 +1009,10 @@
 						var percentage = this.options.ticks_positions[i] ||
 							100 * (this.options.ticks[i] - minTickValue) / (maxTickValue - minTickValue);
 
+						if (this.options.reversed) {
+							percentage = 100 - percentage;
+						}
+
 						this.ticks[i].style[this.stylePos] = percentage + '%';
 
 						/* Set class labels to denote whether ticks are in the selection */
@@ -1028,7 +1032,7 @@
 
 							if (this.options.ticks_positions[i] !== undefined) {
 								this.tickLabels[i].style.position = 'absolute';
-								this.tickLabels[i].style[this.stylePos] = this.options.ticks_positions[i] + '%';
+								this.tickLabels[i].style[this.stylePos] = percentage + '%';
 								this.tickLabels[i].style[styleMargin] = -labelSize/2 + 'px';
 							}
 						}


### PR DESCRIPTION
Simple fix to reverse the tick positions when "reversed=true" has been set in the slider options.