### PR TITLE
Horizontal tick label fix

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -1017,23 +1017,15 @@
 				if (Array.isArray(this.options.ticks) && this.options.ticks.length > 0) {
 
 					var styleSize = this.options.orientation === 'vertical' ? 'height' : 'width';
-					var styleMargin = this.options.orientation === 'vertical' ? 'marginTop' : 'marginLeft';
-					var labelSize = this._state.size / (this.options.ticks.length - 1);
+					var labelSize = 1 / (this.options.ticks.length);
+					labelSize = labelSize * 100;
 
 					if (this.tickLabelContainer) {
 						var extraMargin = 0;
-						if (this.options.ticks_positions.length === 0) {
-							if (this.options.orientation !== 'vertical') {
-								this.tickLabelContainer.style[styleMargin] = -labelSize/2 + 'px';
-							}
-
-							extraMargin = this.tickLabelContainer.offsetHeight;
-						} else {
-							/* Chidren are position absolute, calculate height by finding the max offsetHeight of a child */
-							for (i = 0 ; i < this.tickLabelContainer.childNodes.length; i++) {
-								if (this.tickLabelContainer.childNodes[i].offsetHeight > extraMargin) {
-									extraMargin = this.tickLabelContainer.childNodes[i].offsetHeight;
-								}
+						/* Chidren are position absolute, calculate height by finding the max offsetHeight of a child */
+						for (i = 0 ; i < this.tickLabelContainer.childNodes.length; i++) {
+							if (this.tickLabelContainer.childNodes[i].offsetHeight > extraMargin) {
+								extraMargin = this.tickLabelContainer.childNodes[i].offsetHeight;
 							}
 						}
 						if (this.options.orientation === 'horizontal') {
@@ -1063,16 +1055,18 @@
 						}
 
 						if (this.tickLabels[i]) {
-							this.tickLabels[i].style[styleSize] = labelSize + 'px';
-
-							if (this.options.orientation !== 'vertical' && this.options.ticks_positions[i] !== undefined) {
-								this.tickLabels[i].style.position = 'absolute';
-								this.tickLabels[i].style[this.stylePos] = percentage + '%';
-								this.tickLabels[i].style[styleMargin] = -labelSize/2 + 'px';
-							} else if (this.options.orientation === 'vertical') {
-								this.tickLabels[i].style['marginLeft'] =  this.sliderElem.offsetWidth + 'px';
-								this.tickLabelContainer.style['marginTop'] = this.sliderElem.offsetWidth / 2 * -1 + 'px';
-							}
+							this.tickLabels[i].style[styleSize] = labelSize + '%';
+							this.tickLabels[i].style.position = 'absolute';
+							if (this.options.orientation === 'horizontal') {
+				                this.tickLabels[i].style['transform'] = 'translate(-50%, 0%)';
+				            } else {
+				                this.tickLabels[i].style['transform'] = 'translate(0%, -' + labelSize + '%)';
+				            }
+							if (this.options.ticks_positions[i] !== undefined) {
+				                this.tickLabels[i].style[this.stylePos] = this.options.ticks_positions[i] + '%';
+				            } else {
+				                this.tickLabels[i].style[this.stylePos] = (labelSize + labelSize/ (this.options.ticks.length -1) ) *  i  + '%';
+				            }
 						}
 					}
 				}

--- a/test/specs/WindowResizeTickLabelSpec.js
+++ b/test/specs/WindowResizeTickLabelSpec.js
@@ -1,0 +1,52 @@
+/*
+  *************************
+
+  Window resize test
+
+  *************************
+
+  This spec tests if Window resizes, tick labels should have been on right position
+*/
+describe("Window resize, test", function() {
+  var testSlider;
+
+    it("Should show the correct number of tick labes", function() {
+  		var options = {
+  			ticks: [100, 200, 300, 400, 500],
+            ticks_labels: ['100', '200', '300', '400', '500'],
+  			value: 250,
+  			selection: 'after'
+  		},
+  		$el = $("#testSlider1");
+
+  		testSlider = $el.slider(options);
+  		expect($el.siblings('div.slider').find('.slider-tick-label').length).toBe(5);
+    });
+
+    it("Should have the correct tick labes at it's position initially and after resize", function() {
+        var tick = [100, 200, 300, 400, 500];
+        var options = {
+            ticks: tick,
+            ticks_labels: ['100', '200', '300', '400', '500'],
+            value: 250,
+            selection: 'after'
+        },
+        per = 1/tick.length,
+        $el = $("#testSlider1");
+
+        testSlider = $el.slider(options);
+
+        window.onresize = function() {
+            $("div.slider").width($(window).width());
+        };
+
+        expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').width()).toBe($el.siblings('div.slider').width()*per);
+        $(window).trigger('resize');
+        expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').width()).toBe($el.siblings('div.slider').width()*per);
+    });
+	
+	afterEach(function() {
+		testSlider.slider('destroy');
+		testSlider = null;
+	});
+});


### PR DESCRIPTION
HI, We were using `bootstrap-slider` for our project and found this issue, where when you resize the window the tick labels are not able update its new position with respect to the new resized window.

I tried to solve it with the help of using % width for labels instead of size/ (no of ticks) , the size is available in state.

Here are the two fiddles which shows the problem and solution (may be `approx`)

Fiddle, with original code:
https://jsfiddle.net/raviojha/g1cm1gsj/

Fiddle with updated code, with slide correction  :
https://jsfiddle.net/raviojha/b8b1gu5f/1/

Note: you need to resize the window (or result window) (horizontally) to see the difference.