### PR TITLE
Fix tick mark position in logarithmic scale

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -980,8 +980,6 @@
 
 				/* Position ticks and labels */
 				if (Array.isArray(this.options.ticks) && this.options.ticks.length > 0) {
-					var maxTickValue = Math.max.apply(Math, this.options.ticks);
-					var minTickValue = Math.min.apply(Math, this.options.ticks);
 
 					var styleSize = this.options.orientation === 'vertical' ? 'height' : 'width';
 					var styleMargin = this.options.orientation === 'vertical' ? 'marginTop' : 'marginLeft';
@@ -1006,8 +1004,7 @@
 					}
 					for (var i = 0; i < this.options.ticks.length; i++) {
 
-						var percentage = this.options.ticks_positions[i] ||
-							100 * (this.options.ticks[i] - minTickValue) / (maxTickValue - minTickValue);
+						var percentage = this.options.ticks_positions[i] || this._toPercentage(this.options.ticks[i]);
 
 						this.ticks[i].style[this.stylePos] = percentage + '%';
 

--- a/test/specs/LogarithmicScaleSpec.js
+++ b/test/specs/LogarithmicScaleSpec.js
@@ -11,7 +11,7 @@ describe("Slider with logarithmic scale tests", function() {
 
 	var testSlider;
 
-	it("Should have the number of tick marks you specify", function() {
+	it("Should properly position the slider", function() {
 		testSlider = $("#testSlider1").slider({
 			min: 0,
 			max: 10000,
@@ -23,6 +23,21 @@ describe("Slider with logarithmic scale tests", function() {
 
 		var handle = $("#testSlider1").siblings('div.slider').find('.min-slider-handle');
 		expect(handle.css('left')).toBe(expectedPostition);
+	});
+
+	it("Should properly position the tick marks", function() {
+		testSlider = $("#testSlider1").slider({
+			min: 0,
+			max: 100,
+			scale: 'logarithmic',
+			ticks: [0,10,20,50,100]
+		});
+
+		// Position expected for the '10' tick
+		var expectedTickOnePosition = 210 / 2 + 'px'; //should be at 50%
+		
+		var handle = $("#testSlider1").siblings('div.slider').find(".slider-tick").eq(1);
+		expect(handle.css('left')).toBe(expectedTickOnePosition);
 	});
 
 	it("Should use step size when navigating the keyboard", function() {


### PR DESCRIPTION
Fixes #419 

Hi there - I changed the tick positions to follow whatever percentages the current scale uses - it was previously only positioning ticks by linear scale.

Here's a JSFiddle with the fix shown
https://jsfiddle.net/ppdtt6cz/3/

I added a test, and also made a small edit to another logarithmic test description to better indicate what it is testing.