### PR TITLE
Fix label positions when using slider in vertical orientation.

### DIFF
--- a/css/bootstrap-slider.css
+++ b/css/bootstrap-slider.css
@@ -104,6 +104,12 @@
   border-left-color: #0480be;
   margin-left: 0;
 }
+.slider.slider-vertical .slider-tick-label-container {
+  white-space: nowrap;
+}
+.slider.slider-vertical .slider-tick-label-container .slider-tick-label {
+  padding-left: 4px;
+}
 .slider.slider-disabled .slider-handle {
   background-image: -webkit-linear-gradient(top, #dfdfdf 0%, #bebebe 100%);
   background-image: -o-linear-gradient(top, #dfdfdf 0%, #bebebe 100%);

--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -997,7 +997,10 @@
 					if (this.tickLabelContainer) {
 						var extraMargin = 0;
 						if (this.options.ticks_positions.length === 0) {
-							this.tickLabelContainer.style[styleMargin] = -labelSize/2 + 'px';
+							if (this.options.orientation !== 'vertical') {
+								this.tickLabelContainer.style[styleMargin] = -labelSize/2 + 'px';
+							}
+							
 							extraMargin = this.tickLabelContainer.offsetHeight;
 						} else {
 							/* Chidren are position absolute, calculate height by finding the max offsetHeight of a child */
@@ -1036,10 +1039,13 @@
 						if (this.tickLabels[i]) {
 							this.tickLabels[i].style[styleSize] = labelSize + 'px';
 
-							if (this.options.ticks_positions[i] !== undefined) {
+							if (this.options.orientation !== 'vertical' && this.options.ticks_positions[i] !== undefined) {
 								this.tickLabels[i].style.position = 'absolute';
 								this.tickLabels[i].style[this.stylePos] = percentage + '%';
 								this.tickLabels[i].style[styleMargin] = -labelSize/2 + 'px';
+							} else if (this.options.orientation === 'vertical') {
+								this.tickLabels[i].style['marginLeft'] =  this.sliderElem.offsetWidth + 'px';
+								this.tickLabelContainer.style['marginTop'] = this.sliderElem.offsetWidth / 2 * -1 + 'px';
 							}
 						}
 					}

--- a/less/rules.less
+++ b/less/rules.less
@@ -73,6 +73,13 @@
 				margin-left: 0;
 			}
 		}
+		.slider-tick-label-container {
+			white-space: nowrap;
+			
+			.slider-tick-label {
+				padding-left: @slider-line-height * .2;
+			}
+		}
 	}
 	&.slider-disabled {
 		.slider-handle {

--- a/sass/slider.scss
+++ b/sass/slider.scss
@@ -100,6 +100,13 @@ $baseBorderRadius: 4px;
       border-left-color: #0480be;
       margin-left: 0;
     }
+    .slider-tick-label-container {
+      white-space: nowrap;
+
+      .slider-tick-label {
+        padding-left: $baseLineHeight * .2;
+      }
+    }
   }
 }
 &.slider-disabled {

--- a/test/specs/TickLabelSpec.js
+++ b/test/specs/TickLabelSpec.js
@@ -48,7 +48,7 @@ describe("Tick Label Render Tests", function() {
 		});	
 		
 		//check elements exist within the bounds of the slider
-		it("Tick labels render inside the slider" + orientation, function() {
+		it("Tick labels render inside the slider's bounds" + orientation, function() {
 			expect($(sliderId).length).toBe(1);
 			
 			var sliderRect = $(sliderId)[0].getBoundingClientRect();
@@ -62,13 +62,9 @@ describe("Tick Label Render Tests", function() {
 					expect(labelRect.top + 10 >= sliderRect.top).toBeTruthy();
 				} else {
 					expect(labelRect.top + 10 >= sliderRect.top).toBeTruthy();
+					expect(labelRect.width / 2 + labelRect.left >= sliderRect.left).toBeTruthy();
 				}
 			}
-		});
-		
-				
-		it("Tick labels render next to the tick positions" + orientation, function() {
-			expect(false).toBe(false);
 		});
 	}
 	

--- a/test/specs/TickLabelSpec.js
+++ b/test/specs/TickLabelSpec.js
@@ -1,0 +1,78 @@
+/*
+	Tick label Render Tests - Tests that labels render in correct positions in both horizontal and vertical orientation
+*/
+
+describe("Tick Label Render Tests", function() {			
+	var testSliderH;
+	var testSliderV;
+	
+	//setup
+	beforeEach(function() {
+		testSliderH = $('#testSlider1').slider({
+			id: 'slider1',
+			ticks: [0, 1, 2],
+			ticks_labels:['x', 'y', 'z'],
+			orientation:'horizontal'
+		});
+		
+		testSliderV = $('#testSlider2').slider({
+			id: 'slider2',
+			ticks: [0, 1, 2],
+			ticks_labels:['x', 'y', 'z'],
+			orientation:'vertical'
+		});
+	});
+	
+	//cleanup
+	afterEach(function() {
+		testSliderH.slider('destroy');
+		testSliderH = null;
+		
+		testSliderV.slider('destroy');
+		testSliderV = null;
+	});
+		
+	//e.g. testOrientation('horizontal', 2) will test the horizontal
+	//code path using control with the id testSlider2 
+	function testOrientation(orientation) {
+		var sliderIndex = orientation.toLowerCase() === 'horizontal' ? 1 : 2;
+		var isVertical = orientation.toLowerCase() === 'horizontal' ? false : true; 
+		var sliderId = '#slider' + sliderIndex;
+		
+		//check elements exist
+		it("Tick labels are rendered - " + orientation, function() {
+			expect($(sliderId).length).toBe(1);
+			
+			var length = $(sliderId + ' .slider-tick-label').length;		
+			expect(length).toBe(3);
+		});	
+		
+		//check elements exist within the bounds of the slider
+		it("Tick labels render inside the slider" + orientation, function() {
+			expect($(sliderId).length).toBe(1);
+			
+			var sliderRect = $(sliderId)[0].getBoundingClientRect();
+			var tickLabels = $(sliderId + ' .slider-tick-label');
+			
+			for (var i = 0; i < tickLabels.length; i++) {
+				var labelRect = tickLabels[i].getBoundingClientRect();
+				
+				if (isVertical) {
+					expect(labelRect.left).toBeGreaterThan(sliderRect.left);
+					expect(labelRect.top + 10 >= sliderRect.top).toBeTruthy();
+				} else {
+					expect(labelRect.top + 10 >= sliderRect.top).toBeTruthy();
+				}
+			}
+		});
+		
+				
+		it("Tick labels render next to the tick positions" + orientation, function() {
+			expect(false).toBe(false);
+		});
+	}
+	
+	//test both horizontal and vertical orientations
+	testOrientation('horizontal');
+	testOrientation('vertical');
+});


### PR DESCRIPTION
Using the slider in vertical orientation with labels has the labels rendering in the incorrect location. The fix renders the labels in a more appropriate position when using the slider in vertical orientation.

![image](https://cloud.githubusercontent.com/assets/1439210/10842017/ccd08b4e-7f31-11e5-818f-444304152a9f.png)

Original
http://jsfiddle.net/seshi/mh3d14ze/

Fix
http://jsfiddle.net/seshi/smogd9mk/