### PR TITLE
Better accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Options can be passed either as a data (data-slider-foo) attribute, or as part o
 | ticks_snap_bounds | float | 0 | Used to define the snap bounds of a tick. Snaps to the tick if value is within these bounds. |
 | scale | string | 'linear' | Set to 'logarithmic' to use a logarithmic scale. |
 | focus | bool | false | Focus the appropriate slider handle after a value change. |
+| labelledby | string,array | null | ARIA labels for the slider handle's, Use array for multiple values in a range slider. |
 
 Functions
 =========

--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -416,9 +416,15 @@
 
 				sliderMinHandle = document.createElement("div");
 				sliderMinHandle.className = "slider-handle min-slider-handle";
+				sliderMinHandle.setAttribute('role', 'slider');
+				sliderMinHandle.setAttribute('aria-valuemin', this.options.min);
+				sliderMinHandle.setAttribute('aria-valuemax', this.options.max);
 
 				sliderMaxHandle = document.createElement("div");
 				sliderMaxHandle.className = "slider-handle max-slider-handle";
+				sliderMaxHandle.setAttribute('role', 'slider');
+				sliderMaxHandle.setAttribute('aria-valuemin', this.options.min);
+				sliderMaxHandle.setAttribute('aria-valuemax', this.options.max);
 
 				sliderTrack.appendChild(sliderTrackLow);
 				sliderTrack.appendChild(sliderTrackSelection);
@@ -474,14 +480,17 @@
 				/* Create tooltip elements */
 				var sliderTooltip = document.createElement("div");
 				sliderTooltip.className = "tooltip tooltip-main";
+				sliderTooltip.setAttribute('role', 'presentation');
 				createAndAppendTooltipSubElements(sliderTooltip);
 
 				var sliderTooltipMin = document.createElement("div");
 				sliderTooltipMin.className = "tooltip tooltip-min";
+				sliderTooltipMin.setAttribute('role', 'presentation');
 				createAndAppendTooltipSubElements(sliderTooltipMin);
 
 				var sliderTooltipMax = document.createElement("div");
 				sliderTooltipMax.className = "tooltip tooltip-max";
+				sliderTooltipMax.setAttribute('role', 'presentation');
 				createAndAppendTooltipSubElements(sliderTooltipMax);
 
 
@@ -985,7 +994,10 @@
 				}
 
 				this.handle1.style[this.stylePos] = positionPercentages[0]+'%';
+				this.handle1.setAttribute('aria-valuenow', this._state.value[0]);
+
 				this.handle2.style[this.stylePos] = positionPercentages[1]+'%';
+				this.handle2.setAttribute('aria-valuenow', this._state.value[1]);
 
 				/* Position ticks and labels */
 				if (Array.isArray(this.options.ticks) && this.options.ticks.length > 0) {
@@ -1000,7 +1012,7 @@
 							if (this.options.orientation !== 'vertical') {
 								this.tickLabelContainer.style[styleMargin] = -labelSize/2 + 'px';
 							}
-							
+
 							extraMargin = this.tickLabelContainer.offsetHeight;
 						} else {
 							/* Chidren are position absolute, calculate height by finding the max offsetHeight of a child */

--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -430,6 +430,19 @@
 				sliderTrack.appendChild(sliderTrackSelection);
 				sliderTrack.appendChild(sliderTrackHigh);
 
+				/* Add aria-labelledby to handle's */
+				var isLabelledbyArray = Array.isArray(this.options.labelledby);
+				if (isLabelledbyArray && this.options.labelledby[0]) {
+					sliderMinHandle.setAttribute('aria-labelledby', this.options.labelledby[0]);
+				}
+				if (isLabelledbyArray && this.options.labelledby[1]) {
+					sliderMaxHandle.setAttribute('aria-labelledby', this.options.labelledby[1]);
+				}
+				if (!isLabelledbyArray && this.options.labelledby) {
+					sliderMinHandle.setAttribute('aria-labelledby', this.options.labelledby);
+					sliderMaxHandle.setAttribute('aria-labelledby', this.options.labelledby);
+				}
+
 				/* Create ticks */
 				this.ticks = [];
 				if (Array.isArray(this.options.ticks) && this.options.ticks.length > 0) {
@@ -739,7 +752,8 @@
 				ticks_snap_bounds: 0,
 				scale: 'linear',
 				focus: false,
-				tooltip_position: null
+				tooltip_position: null,
+				labelledby: null
 			},
 
 			getElement: function() {

--- a/test/specs/AccessibilitySpec.js
+++ b/test/specs/AccessibilitySpec.js
@@ -5,10 +5,16 @@ describe("Accessibility Tests", function() {
   it("Should have the slider role", function() {
     sliderA = $('#accessibilitySliderA').slider();
     sliderB = $('#accessibilitySliderB').slider();
+    var $sliderElementA = $(sliderA.slider('getElement'));
+    var $sliderElementB = $(sliderB.slider('getElement'));
 
-    expect($(sliderA.slider('getElement')).find('.min-slider-handle').attr('role')).toBe('slider');
-    expect($(sliderB.slider('getElement')).find('.min-slider-handle').attr('role')).toBe('slider');
-    expect($(sliderB.slider('getElement')).find('.max-slider-handle').attr('role')).toBe('slider');
+    expect($sliderElementA.find('.min-slider-handle').attr('role')).toBe('slider');
+    expect($sliderElementB.find('.min-slider-handle').attr('role')).toBe('slider');
+    expect($sliderElementB.find('.max-slider-handle').attr('role')).toBe('slider');
+
+    expect($sliderElementA.find('.tooltip-main').attr('role')).toBe('presentation');
+    expect($sliderElementA.find('.tooltip-min').attr('role')).toBe('presentation');
+    expect($sliderElementA.find('.tooltip-max').attr('role')).toBe('presentation');
   });
 
   it('Should have an aria-labelledby attribute', function() {
@@ -23,30 +29,34 @@ describe("Accessibility Tests", function() {
   it('Should have an aria-valuemax and aria-valuemin value', function() {
     sliderA = $('#accessibilitySliderA').slider({ min: 5, max: 10 });
     sliderB = $('#accessibilitySliderB').slider({ min: 5, max: 10 });
+    var $sliderElementA = $(sliderA.slider('getElement'));
+    var $sliderElementB = $(sliderB.slider('getElement'));
 
-    expect($(sliderA.slider('getElement')).find('.min-slider-handle').attr('aria-valuemin')).toBe('5');
-    expect($(sliderA.slider('getElement')).find('.min-slider-handle').attr('aria-valuemax')).toBe('10');
-    expect($(sliderB.slider('getElement')).find('.min-slider-handle').attr('aria-valuemin')).toBe('5');
-    expect($(sliderB.slider('getElement')).find('.min-slider-handle').attr('aria-valuemax')).toBe('10');
-    expect($(sliderB.slider('getElement')).find('.max-slider-handle').attr('aria-valuemin')).toBe('5');
-    expect($(sliderB.slider('getElement')).find('.max-slider-handle').attr('aria-valuemax')).toBe('10');
+    expect($sliderElementA.find('.min-slider-handle').attr('aria-valuemin')).toBe('5');
+    expect($sliderElementA.find('.min-slider-handle').attr('aria-valuemax')).toBe('10');
+    expect($sliderElementB.find('.min-slider-handle').attr('aria-valuemin')).toBe('5');
+    expect($sliderElementB.find('.min-slider-handle').attr('aria-valuemax')).toBe('10');
+    expect($sliderElementB.find('.max-slider-handle').attr('aria-valuemin')).toBe('5');
+    expect($sliderElementB.find('.max-slider-handle').attr('aria-valuemax')).toBe('10');
   });
 
   it('Should have an aria-valuenow with the current value', function() {
     sliderA = $('#accessibilitySliderA').slider({ min: 5, value: 7 });
     sliderB = $('#accessibilitySliderB').slider({ min: 5, value: [2, 8] });
+    var $sliderElementA = $(sliderA.slider('getElement'));
+    var $sliderElementB = $(sliderB.slider('getElement'));
 
-    expect($(sliderA.slider('getElement')).find('.min-slider-handle').attr('aria-valuenow')).toBe('7');
-    expect($(sliderB.slider('getElement')).find('.min-slider-handle').attr('aria-valuenow')).toBe('5');
-    expect($(sliderB.slider('getElement')).find('.max-slider-handle').attr('aria-valuenow')).toBe('8');
+    expect($sliderElementA.find('.min-slider-handle').attr('aria-valuenow')).toBe('7');
+    expect($sliderElementB.find('.min-slider-handle').attr('aria-valuenow')).toBe('5');
+    expect($sliderElementB.find('.max-slider-handle').attr('aria-valuenow')).toBe('8');
 
     // Change the value and check if aria-valuenow is still the same
     sliderA.slider('setValue', 1);
     sliderB.slider('setValue', [4, 9]);
 
-    expect($(sliderA.slider('getElement')).find('.min-slider-handle').attr('aria-valuenow')).toBe('5');
-    expect($(sliderB.slider('getElement')).find('.min-slider-handle').attr('aria-valuenow')).toBe('5');
-    expect($(sliderB.slider('getElement')).find('.max-slider-handle').attr('aria-valuenow')).toBe('9');
+    expect($sliderElementA.find('.min-slider-handle').attr('aria-valuenow')).toBe('5');
+    expect($sliderElementB.find('.min-slider-handle').attr('aria-valuenow')).toBe('5');
+    expect($sliderElementB.find('.max-slider-handle').attr('aria-valuenow')).toBe('9');
   });
 
   afterEach(function() {

--- a/test/specs/AccessibilitySpec.js
+++ b/test/specs/AccessibilitySpec.js
@@ -1,0 +1,57 @@
+describe("Accessibility Tests", function() {
+  var sliderA;
+  var sliderB;
+
+  it("Should have the slider role", function() {
+    sliderA = $('#accessibilitySliderA').slider();
+    sliderB = $('#accessibilitySliderB').slider();
+
+    expect($(sliderA.slider('getElement')).find('.min-slider-handle').attr('role')).toBe('slider');
+    expect($(sliderB.slider('getElement')).find('.min-slider-handle').attr('role')).toBe('slider');
+    expect($(sliderB.slider('getElement')).find('.max-slider-handle').attr('role')).toBe('slider');
+  });
+
+  it('Should have an aria-labelledby attribute', function() {
+    sliderA = $('#accessibilitySliderA').slider();
+    sliderB = $('#accessibilitySliderB').slider();
+
+    expect($(sliderA.slider('getElement')).find('.min-slider-handle').attr('aria-labelledby')).toBe('accessibilitySliderLabelA');
+    expect($(sliderB.slider('getElement')).find('.min-slider-handle').attr('aria-labelledby')).toBe('accessibilitySliderLabelA');
+    expect($(sliderB.slider('getElement')).find('.max-slider-handle').attr('aria-labelledby')).toBe('accessibilitySliderLabelB');
+  });
+
+  it('Should have an aria-valuemax and aria-valuemin value', function() {
+    sliderA = $('#accessibilitySliderA').slider({ min: 5, max: 10 });
+    sliderB = $('#accessibilitySliderB').slider({ min: 5, max: 10 });
+
+    expect($(sliderA.slider('getElement')).find('.min-slider-handle').attr('aria-valuemin')).toBe('5');
+    expect($(sliderA.slider('getElement')).find('.min-slider-handle').attr('aria-valuemax')).toBe('10');
+    expect($(sliderB.slider('getElement')).find('.min-slider-handle').attr('aria-valuemin')).toBe('5');
+    expect($(sliderB.slider('getElement')).find('.min-slider-handle').attr('aria-valuemax')).toBe('10');
+    expect($(sliderB.slider('getElement')).find('.max-slider-handle').attr('aria-valuemin')).toBe('5');
+    expect($(sliderB.slider('getElement')).find('.max-slider-handle').attr('aria-valuemax')).toBe('10');
+  });
+
+  it('Should have an aria-valuenow with the current value', function() {
+    sliderA = $('#accessibilitySliderA').slider({ min: 5, value: 7 });
+    sliderB = $('#accessibilitySliderB').slider({ min: 5, value: [2, 8] });
+
+    expect($(sliderA.slider('getElement')).find('.min-slider-handle').attr('aria-valuenow')).toBe('7');
+    expect($(sliderB.slider('getElement')).find('.min-slider-handle').attr('aria-valuenow')).toBe('5');
+    expect($(sliderB.slider('getElement')).find('.max-slider-handle').attr('aria-valuenow')).toBe('8');
+
+    // Change the value and check if aria-valuenow is still the same
+    sliderA.slider('setValue', 1);
+    sliderB.slider('setValue', [4, 9]);
+
+    expect($(sliderA.slider('getElement')).find('.min-slider-handle').attr('aria-valuenow')).toBe('5');
+    expect($(sliderB.slider('getElement')).find('.min-slider-handle').attr('aria-valuenow')).toBe('5');
+    expect($(sliderB.slider('getElement')).find('.max-slider-handle').attr('aria-valuenow')).toBe('9');
+  });
+
+  afterEach(function() {
+    if(sliderA) { sliderA.slider('destroy'); }
+    if(sliderB) { sliderB.slider('destroy'); }
+  });
+
+});

--- a/tpl/SpecRunner.tpl
+++ b/tpl/SpecRunner.tpl
@@ -65,6 +65,13 @@
 		<input id="relayoutSliderInput" type="text"/>
 	</div>
 
+  <!-- Sliders used for AccessibilitySpec -->
+	<div>
+		<span id="accessibilitySliderLabelA">Label A</span>
+		<span id="accessibilitySliderLabelB">Label B</span>
+		<input id="accessibilitySliderA" type="text" data-slider-labelledby="accessibilitySliderLabelA" />
+		<input id="accessibilitySliderB" type="text" data-slider-labelledby='["accessibilitySliderLabelA", "accessibilitySliderLabelB"]' />
+	</div>
 	<% with (scripts) { %>
 	  <% [].concat(jasmine, vendor, src, specs, reporters, start).forEach(function(script){ %>
 	  <script src="<%= script %>"></script>

--- a/tpl/index.tpl
+++ b/tpl/index.tpl
@@ -857,6 +857,55 @@ new Slider("#ex16b", { min: 0, max: 10, value: [0, 10], focus: true });
               </pre>
       </div>
 
+      <div class="slider-example">
+        <h3>Example 18:</h3>
+        <p>Accessibility with ARIA labels</p>
+
+        <div class="well">
+          Slider with single value and label:<br/><br/>
+          <span id="ex18-label-1" class="hidden">
+            Example slider label
+          </span>
+          <input id="ex18a" type="text" /><br/><br/><br/>
+
+          Range slider with multiple labels:<br/><br/>
+          <span id="ex18-label-2a" class="hidden">
+            Example low value
+          </span>
+          <span id="ex18-label-2b" class="hidden">
+            Example high value
+          </span>
+          <input id="ex18b" type="text" />
+        </div>
+
+        <pre>
+          <code>
+        ###################
+        HTML
+        ###################
+        &lt;span id="ex18-label-1" class="hidden"&gt;Example slider label&lt;/span&gt;
+        &lt;input id="ex18a" type="text"/&gt;
+
+        &lt;span id="ex18-label-2a" class="hidden"&gt;Example low value&lt;/span&gt;
+        &lt;span id="ex18-label-2b" class="hidden"&gt;Example high value&lt;/span&gt;
+        &lt;input id="ex18b" type="text"/&gt;
+
+        ###################
+        JavaScript
+        ###################
+
+        // With JQuery
+        $("#ex18a").slider({min  : 0, max  : 10, value: 5, labelledby: 'ex18-label-1'});
+        $("#ex18b").slider({min  : 0, max  : 10, value: [3, 6], labelledby: ['ex18-label-2a', 'ex18-label-2b']});
+
+        // Without JQuery
+        new Slider("#ex18a", {min  : 0, max  : 10, value: 5, labelledby: 'ex18-label-1'});
+        new Slider("#ex18b", {min  : 0, max  : 10, value: [3, 6], olabelledby: ['ex18-label-2a', 'ex18-label-2b']});
+          </code>
+        </pre>
+
+      </div>
+
 
 	  </div> <!-- /examples -->
     </div> <!-- /container -->
@@ -1017,6 +1066,21 @@ new Slider("#ex16b", { min: 0, max: 10, value: [0, 10], focus: true });
 				value: 0,
 				orientation: 'vertical',
 				tooltip_position:'left'
+			});
+
+			/* Example 18 */
+			$('#ex18a').slider({
+				min  : 0,
+				max  : 10,
+				value: 5,
+				labelledby: 'ex18-label-1'
+			});
+
+			$('#ex18b').slider({
+				min  : 0,
+				max  : 10,
+				value: [3, 6],
+				labelledby: ['ex18-label-2a', 'ex18-label-2b']
 			});
 		});
     </script>


### PR DESCRIPTION
Currently the values are not read back to screenreaders, I've tried to add some accessibility based off http://www.oaa-accessibility.org/examplep/slider1/.

Example: http://jsfiddle.net/f2xsjc0j/1/

Before:
![old_situation](https://cloud.githubusercontent.com/assets/570297/11470899/a74192c2-9761-11e5-880c-ea9c97ec989b.png)

After:
![new_situation](https://cloud.githubusercontent.com/assets/570297/11470909/b58350fa-9761-11e5-9929-515a61f9b0c2.png)
