### PR TITLE
Update how slider value is adjusted based on ticks positions

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -207,25 +207,26 @@
 			linear: {
 				toValue: function(percentage) {
 					var rawValue = percentage/100 * (this.options.max - this.options.min);
+					var shouldAdjustWithBase = true;
 					if (this.options.ticks_positions.length > 0) {
 						var minv, maxv, minp, maxp = 0;
-						for (var i = 0; i < this.options.ticks_positions.length; i++) {
+						for (var i = 1; i < this.options.ticks_positions.length; i++) {
 							if (percentage <= this.options.ticks_positions[i]) {
-								minv = (i > 0) ? this.options.ticks[i-1] : 0;
-								minp = (i > 0) ? this.options.ticks_positions[i-1] : 0;
+								minv = this.options.ticks[i-1];
+								minp = this.options.ticks_positions[i-1];
 								maxv = this.options.ticks[i];
 								maxp = this.options.ticks_positions[i];
 
 								break;
 							}
 						}
-						if (i > 0) {
-							var partialPercentage = (percentage - minp) / (maxp - minp);
-							rawValue = minv + partialPercentage * (maxv - minv);
-						}
+						var partialPercentage = (percentage - minp) / (maxp - minp);
+						rawValue = minv + partialPercentage * (maxv - minv);
+						shouldAdjustWithBase = false;
 					}
 
-					var value = this.options.min + Math.round(rawValue / this.options.step) * this.options.step;
+					var adjustment = shouldAdjustWithBase ? this.options.min : 0;
+					var value = adjustment + Math.round(rawValue / this.options.step) * this.options.step;
 					if (value < this.options.min) {
 						return this.options.min;
 					} else if (value > this.options.max) {

--- a/test/specs/TickClickingBehaviorSpec.js
+++ b/test/specs/TickClickingBehaviorSpec.js
@@ -1,0 +1,107 @@
+describe("TickClickingBehavior", function() {
+	var SLIDER_ID = "testSlider1";
+	var slider;
+	var options;
+
+	describe('ticks start with 0', function() {
+		beforeEach(function() {
+			options = {
+				ticks: [0, 1, 2, 3, 4],
+				ticks_positions: [0, 25, 50, 75, 100],
+				step: 1,
+				value: 4
+			};
+
+			slider = new Slider(document.getElementById(SLIDER_ID), options);
+		});
+
+		it("Should set slider to corresponding value when ticks are clicked", function() {
+			for (var i = 0; i < options.ticks.length; i++) {
+				clickTickAtIndexAndVerify(slider, i);
+			}
+		});
+	});
+
+	describe('ticks start with positive value', function() {
+		beforeEach(function() {
+			options = {
+				ticks: [1, 2, 3, 4, 5],
+				ticks_positions: [0, 25, 50, 75, 100],
+				step: 1,
+				value: 5
+			};
+
+			slider = new Slider(document.getElementById(SLIDER_ID), options);
+		});
+
+		it("Should set slider to corresponding value when ticks are clicked", function() {
+			for (var i = 0; i < options.ticks.length; i++) {
+				clickTickAtIndexAndVerify(slider, i);
+			}
+		});
+	});
+
+	describe('ticks start with negative value', function() {
+		beforeEach(function() {
+			options = {
+				ticks: [-5, -4, -3, -2, -1],
+				ticks_positions: [0, 25, 50, 75, 100],
+				step: 1,
+				value: -1
+			};
+
+			slider = new Slider(document.getElementById(SLIDER_ID), options);
+		});
+
+		it("Should set slider to corresponding value when ticks are clicked", function() {
+			for (var i = 0; i < options.ticks.length; i++) {
+				clickTickAtIndexAndVerify(slider, i);
+			}
+		});
+	});
+
+	afterEach(function() { slider.destroy(); });
+
+	// helper functions
+	function clickTickAtIndexAndVerify(slider, tickIndex) {
+		var sliderLeft = slider.sliderElem.offsetLeft;
+		var tickLeft = slider.ticks[tickIndex].offsetLeft;
+		var handleHalfWidth = $('.slider-handle.round').width() / 2;
+
+		var offsetX = sliderLeft + tickLeft + handleHalfWidth;
+		var offsetY = slider.sliderElem.offsetTop;
+
+		var mouseEvent = getMouseDownEvent(offsetX, offsetY);
+
+		slider.mousedown(mouseEvent);
+		slider.mouseup();
+
+		var expectedValue = slider.options.ticks[tickIndex];
+		expect(slider.getValue()).toBe(expectedValue);
+	}
+
+	function getMouseDownEvent(offsetXToClick, offsetYToClick) {
+		var args = [
+			'mousedown', // type
+			true, // canBubble
+			true, // cancelable
+			document, // view,
+			0, // detail
+			0, // screenX
+			0, // screenY
+			offsetXToClick, // clientX
+			offsetYToClick, // clientY,
+			false, // ctrlKey
+			false, // altKey
+			false, // shiftKey
+			false, // metaKey,
+			0, // button
+			null // relatedTarget
+		];
+
+		var event = document.createEvent('MouseEvents');
+		event.initMouseEvent.apply(event, args);
+
+		return event;
+	}
+});


### PR DESCRIPTION
When _ticks_positions_ are specified, the _raw_value_ calculated based on the percentage should not be adjusted with the _min_ value.

Changes:
* Do not adjust with base (min) after calculated with ticks positions
* Add example 13.a in index.html for the case above