### PR TITLE
Bind _layout() function to window.resize event

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -677,6 +677,7 @@
 			}
 			this.sliderElem.addEventListener("mousedown", this.mousedown, false);
 
+			// Bind window handlers
 			this.resize = this._resize.bind(this);
 			window.addEventListener("resize", this.resize, false);
 
@@ -1172,6 +1173,7 @@
 				this._state.offset = this._offset(this.sliderElem);
 				this._state.size = this.sliderElem[this.sizePos];
         this._layout();
+				this._trigger('resize');
       },
 			_removeProperty: function(element, prop) {
 				if (element.style.removeProperty) {

--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -1176,7 +1176,7 @@
 				this._state.offset = this._offset(this.sliderElem);
 				this._state.size = this.sliderElem[this.sizePos];
 				this._layout();
-      },
+			},
 			_removeProperty: function(element, prop) {
 				if (element.style.removeProperty) {
 				    element.style.removeProperty(prop);

--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -677,6 +677,9 @@
 			}
 			this.sliderElem.addEventListener("mousedown", this.mousedown, false);
 
+			this.resize = this._resize.bind(this);
+			window.addEventListener("resize", this.resize, false);
+
 
 			// Bind tooltip-related handlers
 			if(this.options.tooltip === 'hide') {
@@ -1164,6 +1167,12 @@
 			        }
 				}
 			},
+			_resize: function (ev) {
+				/*jshint unused:false*/
+				this._state.offset = this._offset(this.sliderElem);
+				this._state.size = this.sliderElem[this.sizePos];
+        this._layout();
+      },
 			_removeProperty: function(element, prop) {
 				if (element.style.removeProperty) {
 				    element.style.removeProperty(prop);

--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -957,6 +957,9 @@
 				}
 				this.sliderElem.removeEventListener("touchstart", this.mousedown, false);
 				this.sliderElem.removeEventListener("mousedown", this.mousedown, false);
+
+				// Remove window event listener
+				window.removeEventListener("resize", this.resize, false);
 			},
 			_bindNonQueryEventHandler: function(evt, callback) {
 				if(this.eventToCallbackMap[evt] === undefined) {
@@ -1172,8 +1175,7 @@
 				/*jshint unused:false*/
 				this._state.offset = this._offset(this.sliderElem);
 				this._state.size = this.sliderElem[this.sizePos];
-        this._layout();
-				this._trigger('resize');
+				this._layout();
       },
 			_removeProperty: function(element, prop) {
 				if (element.style.removeProperty) {

--- a/test/specs/EventsSpec.js
+++ b/test/specs/EventsSpec.js
@@ -224,6 +224,16 @@ describe("Event Tests", function() {
 
     });
 
+    describe("Window Events", function() {
+      it("'resize' event is triggered properly and can be binded to", function() {
+        testSlider.on('resize', function() {
+          flag = true;
+        });
+        testSlider.data('slider')._resize();
+        expect(flag).toBeTruthy();
+      });
+    });
+
     describe("Enabled/Disabled tests", function() {
       it("'slideDisabled' event is triggered properly and can be binded to", function() {
         testSlider.on('slideDisabled', function() {

--- a/test/specs/EventsSpec.js
+++ b/test/specs/EventsSpec.js
@@ -224,16 +224,6 @@ describe("Event Tests", function() {
 
     });
 
-    describe("Window Events", function() {
-      it("'resize' event is triggered properly and can be binded to", function() {
-        testSlider.on('resize', function() {
-          flag = true;
-        });
-        testSlider.data('slider')._resize();
-        expect(flag).toBeTruthy();
-      });
-    });
-
     describe("Enabled/Disabled tests", function() {
       it("'slideDisabled' event is triggered properly and can be binded to", function() {
         testSlider.on('slideDisabled', function() {

--- a/test/specs/ResizeSpec.js
+++ b/test/specs/ResizeSpec.js
@@ -1,0 +1,70 @@
+describe("Resize Tests", function() {
+  var testSlider, dataSlider;
+
+  afterEach(function() {
+    if(testSlider) {
+      testSlider.slider('destroy');
+      testSlider = null;
+      dataSlider = null;
+    }
+  });
+
+  describe("Tick Labels", function() {
+
+    var $el, options;
+
+    beforeEach(function() {
+      var tick = [0, 100, 200, 300, 400];
+      options = {
+          ticks: tick,
+          ticks_labels: ['$0', '$100', '$200', '$300', '$400']
+      };
+    });
+
+    it("should resize the tick labels when horizontal", function() {
+
+      $el = $("#resizeSlider");
+      testSlider = $el.slider(options);
+      dataSlider = testSlider.data('slider');
+
+      $('.slider').width(210);
+      dataSlider._resize();
+      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').width()).toBe(52);
+
+      $('.slider').width(120);
+      dataSlider._resize();
+      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').width()).toBe(30);
+
+      $('.slider').width(900);
+      dataSlider._resize();
+      expect($el.siblings('div.slider').find('.slider-tick-label:eq(1)').width()).toBe(225);
+
+      $('.slider').width(210);
+      dataSlider._resize();
+      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').width()).toBe(52);
+    });
+
+    it('should resize the tick labels when vertical', function() {
+
+      var $el = $("#resizeSliderVertical");
+      testSlider = $el.slider(options);
+      dataSlider = testSlider.data('slider');
+
+      $('.slider').height(210);
+      dataSlider._resize();
+      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').height()).toBe(52);
+
+      $('.slider').height(120);
+      dataSlider._resize();
+      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').height()).toBe(30);
+
+      $('.slider').height(900);
+      dataSlider._resize();
+      expect($el.siblings('div.slider').find('.slider-tick-label:eq(1)').height()).toBe(225);
+
+      $('.slider').height(210);
+      dataSlider._resize();
+      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').height()).toBe(52);
+    });
+  });
+}); // End of spec

--- a/tpl/SpecRunner.tpl
+++ b/tpl/SpecRunner.tpl
@@ -65,6 +65,10 @@
 		<input id="relayoutSliderInput" type="text"/>
 	</div>
 
+  <!-- Sliders used by resize -->
+  <input id="resizeSlider" type="text"/>
+  <input id="resizeSliderVertical" data-slider-orientation="vertical" type="text"/>
+
   <!-- Sliders used for AccessibilitySpec -->
 	<div>
 		<span id="accessibilitySliderLabelA">Label A</span>


### PR DESCRIPTION
A number of solutions have been proposed to make the slider labels responsive, this was the most elegant one I've seen, originally proposed in [this thread](https://github.com/seiyria/bootstrap-slider/issues/464).

A visual example of the change can be seen [here](http://jsfiddle.net/zsiswick/76sywz9d/2/). Please try expanding and contracting the result window. Note the responsive labels work for vertical slider orientation as well.