### PR TITLE
Fix for tooltip postion bottom on range slider

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1161,14 +1161,26 @@
 			        var offset_min = this.tooltip_min.getBoundingClientRect();
 			        var offset_max = this.tooltip_max.getBoundingClientRect();
 
-			        if (offset_min.right > offset_max.left) {
-			            this._removeClass(this.tooltip_max, 'top');
-			            this._addClass(this.tooltip_max, 'bottom');
-			            this.tooltip_max.style.top = 18 + 'px';
+			        if (this.options.tooltip_position === 'bottom') {
+			        	if (offset_min.right > offset_max.left) {
+			        		this._removeClass(this.tooltip_max, 'bottom');
+			        		this._addClass(this.tooltip_max, 'top');
+			        		this.tooltip_max.style.top = -14 + 'px';
+			        	} else {
+			        		this._removeClass(this.tooltip_max, 'top');
+			        		this._addClass(this.tooltip_max, 'bottom');
+			        		this.tooltip_max.style.top = this.tooltip_min.style.top;
+			        	}
 			        } else {
-			            this._removeClass(this.tooltip_max, 'bottom');
-			            this._addClass(this.tooltip_max, 'top');
-			            this.tooltip_max.style.top = this.tooltip_min.style.top;
+				        if (offset_min.right > offset_max.left) {
+				            this._removeClass(this.tooltip_max, 'top');
+				            this._addClass(this.tooltip_max, 'bottom');
+				            this.tooltip_max.style.top = 18 + 'px';
+				        } else {
+				            this._removeClass(this.tooltip_max, 'bottom');
+				            this._addClass(this.tooltip_max, 'top');
+				            this.tooltip_max.style.top = this.tooltip_min.style.top;
+				        }
 			        }
 				}
 			},

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1165,11 +1165,13 @@
 			        	if (offset_min.right > offset_max.left) {
 			        		this._removeClass(this.tooltip_max, 'bottom');
 			        		this._addClass(this.tooltip_max, 'top');
-			        		this.tooltip_max.style.top = -14 + 'px';
-			        	} else {
-			        		this._removeClass(this.tooltip_max, 'top');
-			        		this._addClass(this.tooltip_max, 'bottom');
-			        		this.tooltip_max.style.top = this.tooltip_min.style.top;
+			        		this.tooltip_max.style.top = '';
+                            this.tooltip_max.style.bottom = 22 + 'px';
+                        } else {
+                            this._removeClass(this.tooltip_max, 'top');
+                            this._addClass(this.tooltip_max, 'bottom');
+                            this.tooltip_max.style.top = this.tooltip_min.style.top;
+                            this.tooltip_max.style.bottom = '';
 			        	}
 			        } else {
 				        if (offset_min.right > offset_max.left) {

--- a/test/specs/TooltipPositionOptionSpec.js
+++ b/test/specs/TooltipPositionOptionSpec.js
@@ -131,6 +131,28 @@ describe("'tooltip_position' Option tests", function() {
       expect(testSlider.tooltip.style.top).toBe("22px");
     });
 
+    it("should be aligned below the handle if set to 'bottom' for range", function() {
+      // Create slider
+      testSlider = new Slider("#testSlider1", {
+        min: 0,
+        max: 20,
+        value: [0, 10],
+        range: true,
+        tooltip_position: "bottom",
+        orientation: "horizontal"
+      });
+
+      // Extract needed references/values
+      var mainTooltipHasClassTopMin = testSlider.tooltip_min.classList.contains("bottom");
+      var mainTooltipHasClassTopMax = testSlider.tooltip_max.classList.contains("bottom");
+
+      // Assert
+      expect(mainTooltipHasClassTopMin).toBeTruthy();
+      expect(mainTooltipHasClassTopMax).toBeTruthy();
+      expect(testSlider.tooltip_min.style.top).toBe("22px");
+      expect(testSlider.tooltip_max.style.top).toBe("22px");
+    });
+
     it("should default to 'top' if tooltip_position set to 'left'", function() {
       // Create slider
       testSlider = new Slider("#testSlider1", {


### PR DESCRIPTION
Solution for problem when using range and tooltip position set to bottom.
The max tooltip is at top instead of bottom.

See fiddle:
https://jsfiddle.net/b8jtpb0e/

Code changed
```javascript
if (this.options.tooltip_position === 'bottom') {
	if (offset_min.right > offset_max.left) {
		this._removeClass(this.tooltip_max, 'bottom');
		this._addClass(this.tooltip_max, 'top');
		this.tooltip_max.style.top = -14 + 'px';
	} else {
		this._removeClass(this.tooltip_max, 'top');
		this._addClass(this.tooltip_max, 'bottom');
		this.tooltip_max.style.top = this.tooltip_min.style.top;
	}
}
else {
	if (offset_min.right > offset_max.left) {
		this._removeClass(this.tooltip_max, 'top');
		this._addClass(this.tooltip_max, 'bottom');
		this.tooltip_max.style.top = 18 + 'px';
	} else {
		this._removeClass(this.tooltip_max, 'bottom');
		this._addClass(this.tooltip_max, 'top');
		this.tooltip_max.style.top = this.tooltip_min.style.top;
	}
}
```