### PR TITLE
fix event/input value attribute "race condition"

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -814,6 +814,7 @@
 				this._layout();
 				var newValue = this.options.range ? this._state.value : this._state.value[0];
 
+				this._setDataVal(newValue);
 				if(triggerSlideEvent === true) {
 					this._trigger('slide', newValue);
 				}
@@ -823,7 +824,6 @@
 						newValue: newValue
 					});
 				}
-				this._setDataVal(newValue);
 
 				return this;
 			},

--- a/test/specs/EventsSpec.js
+++ b/test/specs/EventsSpec.js
@@ -47,6 +47,26 @@ describe("Event Tests", function() {
         expect(flag).toBeTruthy();
       });
 
+      it("'slide' event value and input value properties are synchronous", function() {
+        testSlider.on('slide', function(e) {
+          flag = true;
+          expect(e.value.toString()).toEqual(this.value);
+        });
+        testSlider.slider("setValue", 3, true, false);
+
+        expect(flag).toBeTruthy();
+      });
+
+      it("'change' event value and input value properties are synchronous", function() {
+        testSlider.on('change', function(e) {
+          flag = true;
+          expect(e.value.newValue.toString()).toEqual(testSlider.val());
+        });
+        testSlider.slider("setValue", 3, false, true);
+
+        expect(flag).toBeTruthy();
+      });
+
       it("'slideStop' event is triggered properly and can be binded to", function() {
         testSlider.on('slideStop', function() {
           flag = true;
@@ -141,6 +161,30 @@ describe("Event Tests", function() {
           expect(isNaN(testSlider.val())).not.toBeTruthy();
         });
         testSlider.data('slider')._mousemove(touch);
+
+        expect(flag).toBeTruthy();
+      });
+
+      it("'slide' event value and input value properties are synchronous", function() {
+        touch.initEvent("touchmove");
+
+        testSlider.on('slide', function(e) {
+          flag = true;
+          expect(e.value.toString()).toEqual(testSlider.val());
+        });
+        testSlider.slider("setValue", 3, true, false);
+
+        expect(flag).toBeTruthy();
+      });
+
+      it("'change' event value and input value properties are synchronous", function() {
+        touch.initEvent("touchmove");
+
+        testSlider.on('change', function(e) {
+          flag = true;
+          expect(e.value.newValue.toString()).toEqual(testSlider.val());
+        });
+        testSlider.slider("setValue", 3, false, true);
 
         expect(flag).toBeTruthy();
       });


### PR DESCRIPTION
this simple patch sets the input's value attribute
to the new value _before_ triggering events.
it works around the issue of reading the input's 
value attribute (`$(input).val()`) inside an event listener
which would always return the value of the preceding slide step.

so, the following inside an event listener will evaluate to `true`:

```js
event.value.newValue == input.value;
```