### PR TITLE
Fix for vertical slider in Y-scrollable elements after scroll.

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1541,6 +1541,9 @@
 				var offsetTop = obj.offsetTop;
 				while((obj = obj.offsetParent) && !isNaN(obj.offsetTop)){
 					offsetTop += obj.offsetTop;
+					if( obj.tagName !== 'BODY') {
+						offsetTop -= obj.scrollTop;
+					}
 				}
 				return offsetTop;
 			},

--- a/test/specs/ScrollableBodySpec.js
+++ b/test/specs/ScrollableBodySpec.js
@@ -1,0 +1,83 @@
+describe("Scrollable body test", function() {
+    var testSlider;
+    var sliderHandleTopPos;
+    var sliderHandleLeftPos;
+
+    describe("Vertical scrolled body", function() {
+        beforeEach(function() {
+            testSlider = new Slider("#veryLowPositionedSlider", {
+                id: "scrollTestSliderId",
+                orientation: "vertical",
+                min: 0,
+                max: 20,
+                value: 10,
+                step: 1
+            });
+
+            document.body.scrollTop = 2000;
+
+            var sliderHandleEl = document.querySelector("#scrollTestSliderId .slider-handle");
+            var sliderHandleBoundingBoxInfo = sliderHandleEl.getBoundingClientRect();
+            sliderHandleTopPos = sliderHandleBoundingBoxInfo.top;
+            sliderHandleLeftPos = sliderHandleBoundingBoxInfo.left;
+        });
+
+        afterEach(function() {
+            if(testSlider) {
+                testSlider.destroy();
+            }
+            document.body.scrollTop = 0;
+        });
+
+        // The difference between sliderHandleTopPos and mousemoveY is equal to 50 in both cases,
+        // but difference between initial and final slider value is not equal (6 and 4).
+        // It happens because we don't 'hit' the center of handle but the top left corner.
+
+        it("slides up when handle moves upwards after scroll page down", function() {
+            var mousemove = document.createEvent('MouseEvents');
+            var mousemoveX = sliderHandleLeftPos;
+            var mousemoveY = sliderHandleTopPos - 50;
+            var newSliderValue;
+
+            mousemove.initMouseEvent(
+                "mousedown",
+                true /* bubble */,
+                true  /* cancelable */,
+                window,
+                null,
+                0, 0, mousemoveX, mousemoveY, /* coordinates */
+                false, false, false, false, /* modifier keys */
+                0 /*left*/,
+                null
+            );
+            testSlider.sliderElem.dispatchEvent(mousemove);
+            newSliderValue = testSlider.getValue();
+
+            expect(newSliderValue).toEqual(4);
+        });
+
+        it("slides down when handle moves downwards after scroll page down", function() {
+            var mousemove = document.createEvent('MouseEvents');
+            var mousemoveX = sliderHandleLeftPos;
+            var mousemoveY = sliderHandleTopPos + 50;
+            var newSliderValue;
+
+            mousemove.initMouseEvent(
+                "mousedown",
+                true /* bubble */,
+                true /* cancelable */,
+                window,
+                null,
+                0, 0, mousemoveX, mousemoveY, /* coordinates */
+                false, false, false, false, /* modifier keys */
+                0 /*left*/,
+                null
+            );
+            testSlider.sliderElem.dispatchEvent(mousemove);
+            newSliderValue = testSlider.getValue();
+
+            expect(newSliderValue).toEqual(14);
+        });
+    });
+
+});

--- a/test/specs/ScrollableContainerSpec.js
+++ b/test/specs/ScrollableContainerSpec.js
@@ -1,0 +1,85 @@
+describe("Scrollable test", function() {
+    var testSlider;
+    var sliderHandleTopPos;
+    var sliderHandleLeftPos;
+    var scrollableContainer;
+
+    describe("Vertical inside scrollable container", function() {
+        beforeEach(function() {
+            testSlider = new Slider("#ex1", {
+                id: "ex1Slider",
+                orientation: "vertical",
+                min: 0,
+                max: 20,
+                value: 10,
+                step: 1
+            });
+
+            scrollableContainer = document.querySelector('#scrollable-div');
+            scrollableContainer.scrollTop = 145;
+
+            var sliderHandleEl = document.querySelector("#ex1Slider .slider-handle");
+            var sliderHandleBoundingBoxInfo = sliderHandleEl.getBoundingClientRect();
+            sliderHandleTopPos = sliderHandleBoundingBoxInfo.top;
+            sliderHandleLeftPos = sliderHandleBoundingBoxInfo.left;
+
+        });
+
+        afterEach(function() {
+            if(testSlider) {
+                testSlider.destroy();
+            }
+        });
+
+        // The difference between sliderHandleTopPos and mousemoveY is equal to 50 in both cases,
+        // but difference between initial and final slider value is not equal (6 and 4).
+        // It happens because we don't 'hit' the center of handle but the top left corner.
+
+        it("slides up when handle moves upwards inside scrollable element after scrolling", function() {
+            var mousemove = document.createEvent('MouseEvents');
+            var mousemoveX = sliderHandleLeftPos;
+            var mousemoveY = sliderHandleTopPos - 50;
+            var newSliderValue;
+
+            mousemove.initMouseEvent(
+                "mousedown",
+                true /* bubble */,
+                true  /* cancelable */,
+                window,
+                null,
+                0, 0, mousemoveX, mousemoveY, /* coordinates */
+                false, false, false, false, /* modifier keys */
+                0 /*left*/,
+                null
+            );
+            testSlider.sliderElem.dispatchEvent(mousemove);
+            newSliderValue = testSlider.getValue();
+
+            expect(newSliderValue).toEqual(4);
+        });
+
+        it("slides down when handle moves downwards inside scrollable element after scrolling", function() {
+            var mousemove = document.createEvent('MouseEvents');
+            var mousemoveX = sliderHandleLeftPos;
+            var mousemoveY = sliderHandleTopPos + 50;
+            var newSliderValue;
+
+            mousemove.initMouseEvent(
+                "mousedown",
+                true /* bubble */,
+                true /* cancelable */,
+                window,
+                null,
+                0, 0, mousemoveX, mousemoveY, /* coordinates */
+                false, false, false, false, /* modifier keys */
+                0 /*left*/,
+                null
+            );
+            testSlider.sliderElem.dispatchEvent(mousemove);
+            newSliderValue = testSlider.getValue();
+
+            expect(newSliderValue).toEqual(14);
+        });
+    });
+
+}); // End of spec

--- a/tpl/SpecRunner.tpl
+++ b/tpl/SpecRunner.tpl
@@ -16,6 +16,16 @@
 		{
 			background: rgb(255, 0, 0);
 		}
+		#scrollable-div {
+			overflow-y: scroll;
+			width: 300px;
+			height: 150px;
+			position: relative;
+		}
+		#low-div {
+			padding: 2000px 0 500px 0;
+		}
+
 	</style>
 </head>
 <body>
@@ -63,6 +73,16 @@
 
 	<div id="relayoutSliderContainer" style="display: none">
 		<input id="relayoutSliderInput" type="text"/>
+	</div>
+
+	<div id="scrollable-div">
+		<p>just a row</p>
+		<p>just a row</p>
+		<input id="ex1" data-slider-id='ex1Slider' type="text"/>
+	</div>
+
+	<div id="low-div">
+		<input id="veryLowPositionedSlider" type="text"/>
 	</div>
 
   <!-- Sliders used by resize -->


### PR DESCRIPTION
Works fine with body scrolled down.
Per your request, added simple test even for the case when <body> element is scrolled down before interacting with slider.
