### PR TITLE
Auto register data provide

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ var value = mySlider.slider('getValue');
 		.slider('setValue', 7);
 ```
 
+Using bootstrap-slider (via `data-provide`-API)
+======================
+
+Create an input element with the `data-provide="slider"` attribute automatically
+turns it into a slider. Options can be supplied via `data-slider-` attributes.
+
+```html
+<input
+	type="text"
+	name="somename"
+	data-provide="slider"
+	data-slider-ticks="[1, 2, 3]"
+	data-slider-ticks-labels='["short", "medium", "long"]'
+	data-slider-min="1"
+	data-slider-max="3"
+	data-slider-step="1"
+	data-slider-value="3"
+	data-slider-tooltip="hide"
+>
+```
+
 What if there is already a _slider_ plugin bound to the JQuery namespace?
 ======================
 

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1600,6 +1600,11 @@
 		if($) {
 			var namespace = $.fn.slider ? 'bootstrapSlider' : 'slider';
 			$.bridget(namespace, Slider);
+
+			// Auto-Register data-provide="slider" Elements
+			$(function() {
+				$("input[data-provide=slider]")[namespace]();
+			});
 		}
 
 	})( $ );

--- a/test/specs/AutoRegisterDataProvideSpec.js
+++ b/test/specs/AutoRegisterDataProvideSpec.js
@@ -1,0 +1,21 @@
+describe("Auto register data-provide Tests", function() {
+  it("checks that the autoregister Slider was automatically registerd", function() {
+    var $el = $("#autoregisterSlider");
+
+    var sliderInstancesExists = $el.siblings().is(".slider");
+    expect(sliderInstancesExists).toBeTruthy();
+
+    var sliderInstancesCount = $el.siblings(".slider").length;
+    expect(sliderInstancesCount).toEqual(1);
+  });
+
+  it("checks that the autoregistered Slider can be accessed", function() {
+    var $el = $("#autoregisterSlider");
+    
+    expect($el.slider('getValue')).toBe(1);
+
+    $el.slider('setValue', 2);
+
+    expect($el.slider('getValue')).toBe(2);
+  });
+});

--- a/tpl/SpecRunner.tpl
+++ b/tpl/SpecRunner.tpl
@@ -71,6 +71,10 @@
 
 	<input id="makeRangeSlider" type="text"/>
 
+	<div id="autoregisterSliderContainer">
+		<input id="autoregisterSlider" data-provide="slider" data-slider-value="1"/>
+	</div>
+
 	<div id="relayoutSliderContainer" style="display: none">
 		<input id="relayoutSliderInput" type="text"/>
 	</div>

--- a/tpl/index.tpl
+++ b/tpl/index.tpl
@@ -906,6 +906,52 @@ new Slider("#ex16b", { min: 0, max: 10, value: [0, 10], focus: true });
 
       </div>
 
+      <div class="slider-example">
+        <h3>Example 19:</h3>
+        <p>Auto-Register data-provide="slider" Elements</p>
+
+        <div class="well">
+          Slider-Element not accompanied by any custom Javascript:<br/><br/>
+          <span id="ex18-label-1" class="hidden">
+            Example slider label
+          </span>
+          <input id="ex19" type="text"
+                data-provide="slider"
+                data-slider-ticks="[1, 2, 3]"
+                data-slider-ticks-labels='["short", "medium", "long"]'
+                data-slider-min="1"
+                data-slider-max="3"
+                data-slider-step="1"
+                data-slider-value="3"
+                data-slider-tooltip="hide" />
+        </div>
+
+        <pre>
+          <code>
+        ###################
+        HTML
+        ###################
+        &lt;span id="ex18-label-1" class="hidden">Example slider label&lt;/span&gt;
+        &lt;input id="ex19" type="text"
+              data-provide="slider"
+              data-slider-ticks="[1, 2, 3]"
+              data-slider-ticks-labels='["short", "medium", "long"]'
+              data-slider-min="1"
+              data-slider-max="3"
+              data-slider-step="1"
+              data-slider-value="3"
+              data-slider-tooltip="hide" /&gt;
+
+        ###################
+        JavaScript
+        ###################
+
+        // None
+          </code>
+        </pre>
+
+      </div>
+
 
 	  </div> <!-- /examples -->
     </div> <!-- /container -->


### PR DESCRIPTION
This PR activates automatic registering of `<input />` Elements when they are equipped with a `data-provide="slider"` Attribute. This conforms to the way other Bootstrap-Plugins like [bootstrap-datepicker](https://bootstrap-datepicker.readthedocs.org/en/latest/#data-api) work and mimics the Behavior of Bootstrap's own JavaScript-Plugins, ie [Buttons](http://getbootstrap.com/javascript/#buttons) which are enabled by `data-toggle="button"` or similar Attributes.

All Slider-Options can be set with `data-slider-` Attributes, so in most Situations no custom JavaScript-Code would be required anymore.