### PR TITLE
unset the max-width of the slider

### DIFF
--- a/src/less/rules.less
+++ b/src/less/rules.less
@@ -100,6 +100,7 @@
 	}
 	.tooltip-inner {
 		white-space: nowrap;
+		max-width: none;
 	}
 	.hide {
 		display: none;

--- a/src/sass/slider.scss
+++ b/src/sass/slider.scss
@@ -123,6 +123,7 @@ input {
 }
 .tooltip-inner {
   white-space: nowrap;
+  max-width: none;
 }
 .tooltip {
   &.top {


### PR DESCRIPTION
Found a minor CSS issue. Seems bootstrap is giving class tooltop-inner a max width. Those with design-eyes might notice that larger labels won't be centered properly when given an explicit width.

With max-width: 200px
![maxwidth](https://cloud.githubusercontent.com/assets/238058/13588775/596e9e6e-e487-11e5-8cf3-9d05b52c78b8.gif)
Without: 
![maxwidthoff](https://cloud.githubusercontent.com/assets/238058/13588778/5dfdf588-e487-11e5-9224-07278093a923.gif)

Solution is simple, set max-width to none. Developers can still set a width or max-width later in their stylesheets if they wish to override.


