### PR TITLE
Recalculate size on relayout

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -921,6 +921,7 @@
 			},
 
 			relayout: function() {
+				this._resize();
 				this._layout();
 				return this;
 			},

--- a/test/specs/PublicMethodsSpec.js
+++ b/test/specs/PublicMethodsSpec.js
@@ -573,6 +573,38 @@ describe("Public Method Tests", function() {
     expect(tooltipMarginLeft).toBeGreaterThan(0);
   });
 
+  it("relayout: if slider is not displayed on initialization and then displayed later on, relayout() will re-adjust the tick label width", function() {
+    // Setup
+    testSlider = new Slider("#relayoutSliderInputTickLabels", {
+      id: "relayoutSliderTickLabels",
+      min: 0,
+      max: 10,
+      ticks: [0, 5, 10],
+      ticks_labels: ['low', 'mid', 'high'],
+      value: 5
+    });
+
+    var $ticks = $('#relayoutSliderTickLabels').find('.slider-tick-label');
+
+    // Tick-Width should be 0 on slider intialization
+    var i, $tick;
+    for (i = 0; i < $ticks.length; i++) {
+      $tick = $($ticks[i]);
+      expect( parseInt($tick.css('width')) ).toBe(0);
+    }
+
+    // Show slider and call relayout()
+    $('#relayoutSliderContainerTickLabels').css('display', 'block');
+    testSlider.relayout();
+    $('#relayoutSliderContainerTickLabels').css('display', 'none');
+
+    // Tick-Width should re-adjust to be > 0
+    for (i = 0; i < $ticks.length; i++) {
+      $tick = $($ticks[i]);
+      expect( parseInt($tick.css('width')) ).toBeGreaterThan(0);
+    }
+  });
+
   afterEach(function() {
     if(testSlider) {
       if(testSlider instanceof jQuery) { testSlider.slider('destroy'); }

--- a/tpl/SpecRunner.tpl
+++ b/tpl/SpecRunner.tpl
@@ -79,6 +79,10 @@
 		<input id="relayoutSliderInput" type="text"/>
 	</div>
 
+	<div id="relayoutSliderContainerTickLabels" style="display: none">
+		<input id="relayoutSliderInputTickLabels" type="text"/>
+	</div>
+
 	<div id="scrollable-div">
 		<p>just a row</p>
 		<p>just a row</p>

--- a/tpl/index.tpl
+++ b/tpl/index.tpl
@@ -952,6 +952,65 @@ new Slider("#ex16b", { min: 0, max: 10, value: [0, 10], focus: true });
 
       </div>
 
+      <div class="slider-example">
+        <h3>Example 20:</h3>
+        <p>Slider-Elements initially hidden</p>
+
+        <a class="btn btn-primary" href="" id="ex20a">Show</a>
+        <br><br>
+        <div class="well" style="display: none">
+          Slider-Element initially hidden, revealed by Javascript:<br/><br/>
+          <span id="ex18-label-1" class="hidden">
+            Example slider label
+          </span>
+          <input id="ex20" type="text"
+                data-provide="slider"
+                data-slider-ticks="[1, 2, 3]"
+                data-slider-ticks-labels='["short", "medium", "long"]'
+                data-slider-min="1"
+                data-slider-max="3"
+                data-slider-step="1"
+                data-slider-value="3"
+                data-slider-tooltip="hide" />
+        </div>
+
+        <pre>
+          <code>
+        ###################
+        HTML
+        ###################
+        &lt;a class="btn btn-primary" href="" id="ex20a">Show&lt;/a&gt;
+        &lt;div class="well" style="display: none"&gt;
+            &lt;span id="ex18-label-1" class="hidden"&gt;Example slider label&lt;/span&gt;
+            &lt;input id="ex19" type="text"
+                  data-provide="slider"
+                  data-slider-ticks="[1, 2, 3]"
+                  data-slider-ticks-labels='["short", "medium", "long"]'
+                  data-slider-min="1"
+                  data-slider-max="3"
+                  data-slider-step="1"
+                  data-slider-value="3"
+                  data-slider-tooltip="hide" /&gt;
+        &lt;/div&gt;
+
+        ###################
+        JavaScript
+        ###################
+
+        $('#ex20a').on('click', function(e) {
+            $('#ex20a')
+                .parent()
+                .find(' >.well')
+                .toggle()
+                .find('input')
+                .slider('relayout');
+            e.preventDefault();
+        });
+          </code>
+        </pre>
+
+      </div>
+
 
 	  </div> <!-- /examples -->
     </div> <!-- /container -->
@@ -1127,6 +1186,16 @@ new Slider("#ex16b", { min: 0, max: 10, value: [0, 10], focus: true });
 				max  : 10,
 				value: [3, 6],
 				labelledby: ['ex18-label-2a', 'ex18-label-2b']
+			});
+
+			$('#ex20a').on('click', function(e) {
+				$('#ex20a')
+					.parent()
+					.find(' >.well')
+					.toggle()
+					.find('input')
+					.slider('relayout');
+				e.preventDefault();
 			});
 		});
     </script>


### PR DESCRIPTION
If a slider is initially hidden (fior example inside a Bootstrap-Tab or any other `display:none` Container) one ought to call `.relayout`, so that the Slider can update the layout with the now available information (for example, most browsers report a width of 0 before the content is actually shown).

This leads to an issue, that is not yet handled in `.relayout()`:
 1. After the initialization of a hidden slider, `this._state.size` is 0
 2. Calling `.relayout()` after making it visible, internally calls `._layout()` which, among other things, recalculates the tick-lable size `labelSize`
 3. because `labelSize` is calculated based on `this._state.size`, all labels will also have a width of 0 and be displayed incorrect

This PR adds an additional call to `._resize()` into the body of the `.relayout()` method, which will update `this._state.size` before calling into `._layout()`.

The PR also contains an Example which shows how to use a Slider in an initially hidden Element (and reveals the issue, if the fix is not applied) as well as an automated test, which does the same.