### PR TITLE
Fix range slider swapping place on click

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1222,6 +1222,7 @@
 					var diff1 = Math.abs(this._state.percentage[0] - percentage);
 					var diff2 = Math.abs(this._state.percentage[1] - percentage);
 					this._state.dragged = (diff1 < diff2) ? 0 : 1;
+					this._adjustPercentageForRangeSliders(percentage);
 				} else {
 					this._state.dragged = 0;
 				}

--- a/test/specs/DraggingHandlesSpec.js
+++ b/test/specs/DraggingHandlesSpec.js
@@ -53,6 +53,11 @@ describe("Dragging handles tests", function() {
 			testSlider.mousemove(mouseOverlap);
 			expect(testSlider._state.dragged).toBe(1);
 			expect(testSlider.getValue()).toEqual([5, 5]);
+			// Simulator handle overlap with click
+			testSlider.mousemove(mouseOverlap);
+			testSlider.mousedown(mouseLeft);
+			expect(testSlider._state.dragged).toBe(0);
+			expect(testSlider.getValue()).toEqual([4, 5]);
 			// Simulate right over left drag with imprecision in reported percentage
 			testSlider.mousemove(mouseLeft);
 			expect(testSlider._state.dragged).toBe(0);


### PR DESCRIPTION
Fix #547 issue where when range sliders overlap then clicking on the left moves the max handle to the left of the min handle.