### PR TITLE
Add variables to control slider width and height

### DIFF
--- a/src/less/rules.less
+++ b/src/less/rules.less
@@ -3,7 +3,7 @@
 	vertical-align: middle;
 	position: relative;
 	&.slider-horizontal {
-		width: 210px;
+		width: @slider-horizontal-width;
 		height: @slider-line-height;
 		.slider-track {
 			height: (@slider-line-height/2);
@@ -41,7 +41,7 @@
 		}
 	}
 	&.slider-vertical {
-		height: 210px;
+		height: @slider-vertical-height;
 		width: @slider-line-height;
 		.slider-track {
 			width: (@slider-line-height/2);

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -1,1 +1,3 @@
 @slider-line-height: @line-height-computed;
+@slider-horizontal-width: 210px;
+@slider-vertical-height: 210px;

--- a/src/sass/_rules.scss
+++ b/src/sass/_rules.scss
@@ -3,7 +3,7 @@
   vertical-align: middle;
   position: relative;
   &.slider-horizontal {
-    width: 210px;
+    width: $slider-horizontal-width;
     height: $slider-line-height;
     .slider-track {
       height: $slider-line-height/2;
@@ -40,7 +40,7 @@
     }
   }
   &.slider-vertical {
-    height: 210px;
+    height: $slider-vertical-height;
     width: $slider-line-height;
     .slider-track {
       width: $slider-line-height/2;

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -1,2 +1,4 @@
 $slider-line-height: 20px !default;
 $slider-border-radius: 4px !default;
+$slider-horizontal-width: 210px !default;
+$slider-vertical-height: 210px !default;


### PR DESCRIPTION
Adds LESS & SASS variables to control the width of the slider. It defaults to 210px (the currently hardcoded value) but can be overridden.

See #566 for a case that might be resolved with this change.