### PR TITLE
Fix #481: Tick slider not snapping if clicked

### DIFF
--- a/dist/bootstrap-slider.js
+++ b/dist/bootstrap-slider.js
@@ -1376,8 +1376,8 @@ function _typeof(obj) { return obj && typeof Symbol !== "undefined" && obj.const
 				var val = this._calculateValue(true);
 
 				this._layout();
-				this._setDataVal(val);
-				this._trigger('slideStop', val);
+				this._setDataVal(this._snapToValue(val));
+				this._trigger('slideStop', this._snapToValue(val));
 
 				return false;
 			},


### PR DESCRIPTION
Let me know if you need anything else. Issue #481 


Added _snapToValue(val) when calling _setDataVal and ._trigger('slideStop', in the _mouseup function.