### PR TITLE
Tick mark container

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -451,19 +451,18 @@
 				/* Create ticks */
 				this.ticks = [];
 				if (Array.isArray(this.options.ticks) && this.options.ticks.length > 0) {
+					this.ticksContainer = document.createElement('div');
+					this.ticksContainer.className = 'slider-tick-container';
+
 					for (i = 0; i < this.options.ticks.length; i++) {
 						var tick = document.createElement('div');
 						tick.className = 'slider-tick';
-
 						this.ticks.push(tick);
-						sliderTrack.appendChild(tick);
+						this.ticksContainer.appendChild(tick);
 					}
 
 					sliderTrackSelection.className += " tick-slider-selection";
 				}
-
-				sliderTrack.appendChild(sliderMinHandle);
-				sliderTrack.appendChild(sliderMaxHandle);
 
 				this.tickLabels = [];
 				if (Array.isArray(this.options.ticks_labels) && this.options.ticks_labels.length > 0) {
@@ -482,8 +481,7 @@
 					}
 				}
 
-
-				var createAndAppendTooltipSubElements = function(tooltipElem) {
+				const createAndAppendTooltipSubElements = function(tooltipElem) {
 					var arrow = document.createElement("div");
 					arrow.className = "tooltip-arrow";
 
@@ -492,25 +490,23 @@
 
 					tooltipElem.appendChild(arrow);
 					tooltipElem.appendChild(inner);
-
 				};
 
 				/* Create tooltip elements */
-				var sliderTooltip = document.createElement("div");
+				const sliderTooltip = document.createElement("div");
 				sliderTooltip.className = "tooltip tooltip-main";
 				sliderTooltip.setAttribute('role', 'presentation');
 				createAndAppendTooltipSubElements(sliderTooltip);
 
-				var sliderTooltipMin = document.createElement("div");
+				const sliderTooltipMin = document.createElement("div");
 				sliderTooltipMin.className = "tooltip tooltip-min";
 				sliderTooltipMin.setAttribute('role', 'presentation');
 				createAndAppendTooltipSubElements(sliderTooltipMin);
 
-				var sliderTooltipMax = document.createElement("div");
+				const sliderTooltipMax = document.createElement("div");
 				sliderTooltipMax.className = "tooltip tooltip-max";
 				sliderTooltipMax.setAttribute('role', 'presentation');
 				createAndAppendTooltipSubElements(sliderTooltipMax);
-
 
 				/* Append components to sliderElem */
 				this.sliderElem.appendChild(sliderTrack);
@@ -521,6 +517,12 @@
 				if (this.tickLabelContainer) {
 					this.sliderElem.appendChild(this.tickLabelContainer);
 				}
+				if (this.ticksContainer) {
+					this.sliderElem.appendChild(this.ticksContainer);
+				}
+
+				this.sliderElem.appendChild(sliderMinHandle);
+				this.sliderElem.appendChild(sliderMaxHandle);
 
 				/* Append slider element to parent container, right before the original <input> element */
 				parent.insertBefore(this.sliderElem, this.element);

--- a/src/less/rules.less
+++ b/src/less/rules.less
@@ -20,8 +20,10 @@
 		.slider-tick,
 		.slider-handle {
 			margin-left: (-@slider-line-height/2);
-			margin-top: (-@slider-line-height/4);
 			&.triangle {
+				position: relative;
+				top: 50%;
+				transform: translateY(-50%);
 				border-width: 0 (@slider-line-height/2) (@slider-line-height/2) (@slider-line-height/2);
 				width: 0;
 				height: 0;
@@ -29,10 +31,17 @@
 				margin-top: 0;
 			}
 		}
+		.slider-tick-container {
+			white-space: nowrap;
+			position: absolute;
+    	top: 0;
+    	left: 0;
+    	width: 100%;
+		}
 		.slider-tick-label-container {
 			white-space: nowrap;
 			margin-top: @slider-line-height;
-			
+
 			.slider-tick-label {
 				padding-top: @slider-line-height * .2;
 				display: inline-block;
@@ -46,8 +55,7 @@
 		.slider-track {
 			width: (@slider-line-height/2);
 			height: 100%;
-			margin-left: (-@slider-line-height/4);
-			left: 50%;
+			left: 25%;
 			top: 0;
 		}
 		.slider-selection {
@@ -63,7 +71,6 @@
 		}
 		.slider-tick,
 		.slider-handle {
-			margin-left: (-@slider-line-height/4);
 			margin-top: (-@slider-line-height/2);
 			&.triangle {
 				border-width: (@slider-line-height/2) 0 (@slider-line-height/2) (@slider-line-height/2);
@@ -75,7 +82,7 @@
 		}
 		.slider-tick-label-container {
 			white-space: nowrap;
-			
+
 			.slider-tick-label {
 				padding-left: @slider-line-height * .2;
 			}
@@ -131,6 +138,7 @@
 }
 .slider-handle {
 	position: absolute;
+	top: 0;
 	width: @slider-line-height;
 	height: @slider-line-height;
 	background-color: #337ab7;

--- a/src/sass/_rules.scss
+++ b/src/sass/_rules.scss
@@ -20,14 +20,23 @@
     .slider-tick,
     .slider-handle {
       margin-left: -$slider-line-height/2;
-      margin-top: -$slider-line-height/4;
       &.triangle {
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
         border-width: 0 $slider-line-height/2 $slider-line-height/2 $slider-line-height/2;
         width: 0;
         height: 0;
         border-bottom-color: #0480be;
         margin-top: 0;
       }
+    }
+    .slider-tick-container {
+      white-space: nowrap;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
     }
     .slider-tick-label-container {
       white-space: nowrap;
@@ -46,7 +55,7 @@
       width: $slider-line-height/2;
       height: 100%;
       margin-left: -$slider-line-height/4;
-      left: 50%;
+      left: 25%;
       top: 0;
     }
     .slider-selection {
@@ -62,7 +71,6 @@
    }
    .slider-tick,
    .slider-handle {
-    margin-left: -$slider-line-height/4;
     margin-top: -$slider-line-height/2;
     &.triangle {
       border-width: $slider-line-height/2 0 $slider-line-height/2 $slider-line-height/2;
@@ -135,6 +143,7 @@ input {
 
 .slider-handle {
 	position: absolute;
+  top: 0;
 	width:  $slider-line-height;
 	height: $slider-line-height;
   background-color: #337ab7;

--- a/test/specs/ElementDataAttributesSpec.js
+++ b/test/specs/ElementDataAttributesSpec.js
@@ -87,7 +87,7 @@ describe("Element Data Attributes Tests", function() {
       slider = $("#handleSlider").slider({
         id: "handleSliderElem"
       });
-      var handleIsSetToTriangle = $("#handleSliderElem div.slider-track").children("div.slider-handle").hasClass("triangle");
+      var handleIsSetToTriangle = $("#handleSliderElem div.slider-handle").hasClass("triangle");
       expect(handleIsSetToTriangle).toBeTruthy();
     });
 
@@ -95,7 +95,7 @@ describe("Element Data Attributes Tests", function() {
       slider = $("#customHandleSlider").slider({
         id: "customHandleSliderElem"
       });
-      var handleIsSetToCustom = $("#customHandleSliderElem div.slider-track").children("div.slider-handle").hasClass("custom");
+      var handleIsSetToCustom = $("#customHandleSliderElem div.slider-handle").hasClass("custom");
       expect(handleIsSetToCustom).toBeTruthy();
     });
   });

--- a/test/specs/KeyboardSupportSpec.js
+++ b/test/specs/KeyboardSupportSpec.js
@@ -35,7 +35,7 @@ describe("Keyboard Support Tests", function() {
         id: 'testSlider',
         tooltip: 'show'
       });
-      handle1 = $("#testSlider").find(".slider-track > .slider-handle:first");
+      handle1 = $("#testSlider").find(".slider-handle:first");
 
       // Check for no tooltip before focus
       var tooltipIsShown = $("#testSlider").find("div.tooltip").hasClass("in");
@@ -171,7 +171,7 @@ describe("Keyboard Support Tests", function() {
         value: initialSliderVal
       });
       // Focus on handle1
-      handle1 = $("#testSlider").find(".slider-track > .slider-handle:first");
+      handle1 = $("#testSlider").find(".slider-handle:first");
       handle1.focus();
     });
 
@@ -238,7 +238,7 @@ describe("Keyboard Support Tests", function() {
         value: initialSliderVal
       });
       // Focus on handle1
-      handle1 = $("#testSlider").find(".slider-track > .slider-handle:first");
+      handle1 = $("#testSlider").find(".slider-handle:first");
       handle1.focus();
     });
 
@@ -307,7 +307,7 @@ describe("Keyboard Support Tests", function() {
 
     describe("when handle1 tries to overtake handle2 from the left", function() {
       beforeEach(function() {
-        handle1 = $("#testSlider").find(".slider-track > .slider-handle:first");
+        handle1 = $("#testSlider").find(".slider-handle:first");
         handle1.focus();
       });
 
@@ -430,7 +430,7 @@ describe("Keyboard Support Tests", function() {
             reversed: testCase.reversed,
             orientation: testCase.orientation
           });
-          handle1 = $("#testSlider").find(".slider-track > .slider-handle:first");
+          handle1 = $("#testSlider").find(".slider-handle:first");
           handle1.focus();
         });
 

--- a/test/specs/PublicMethodsSpec.js
+++ b/test/specs/PublicMethodsSpec.js
@@ -106,7 +106,7 @@ describe("Public Method Tests", function() {
         handle : handleVal
       });
 
-      var handleIsSetToTriangle = $("#testSlider1").siblings(".slider").children("div.slider-track").children("div.slider-handle").hasClass("triangle");
+      var handleIsSetToTriangle = $("#testSlider1").siblings(".slider").children("div.slider-handle").hasClass("triangle");
       expect(handleIsSetToTriangle).toBeTruthy();
     });
 

--- a/test/specs/TickMarksSpec.js
+++ b/test/specs/TickMarksSpec.js
@@ -168,6 +168,23 @@ describe("Slider with ticks tests", function() {
 		expect(tickLabelsFromDOM).toEqual(reversedTickLabels);
 	});
 
+	it("should wrap all of the ticks within a div with classname '.slider-tick-container'", function() {
+		// Create the slider with ticks
+		var ticks = [0, 100, 200, 300, 400, 600];
+		var $sliderDOMRef = $("#testSlider1");
+
+		// Create reversed slider
+		testSlider = $sliderDOMRef.slider({
+			id: "testSlider1Ref",
+			ticks: ticks,
+			ticks_positions: [0, 30, 70, 90, 100, 130]
+		});
+		
+		// Assert that the ticks are children of the container element
+		var numTicks = $sliderDOMRef.siblings('div.slider').find('.slider-tick-container > .slider-tick').length;
+		expect(numTicks).toBe(ticks.length);
+	});
+
 	afterEach(function() {
     if(testSlider) {
       testSlider.slider('destroy');


### PR DESCRIPTION
Implements the suggestion made by @phazei in: https://github.com/seiyria/bootstrap-slider/issues/500

This PR wraps all of the ticks within a single container element as opposed to being within the `.slider-track` element. This enables individual ticks to be more easily targeted with CSS selectors such as `nth-of-type(n)`


**Screenshot:**

![image](https://cloud.githubusercontent.com/assets/437318/16821163/cf23af0a-4922-11e6-8910-d04f0141c35b.png)





Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [x] unit tests (we use [Jasmine 1.3](http://jasmine.github.io/1.3/introduction.html))
- [x] Link to original Github issue (if this is a bug-fix)
- [x] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
