### PR TITLE
refactor postpublish script into all-in-one release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ Want to use npm? `npm install bootstrap-slider`
 
 Want to get it from a CDN? https://cdnjs.com/libraries/bootstrap-slider
 
-__NOTE for NPM users__: In order to keep the version numbers in our dist/ file consistent with our Github tags, we do a patch version bump, generate a new dist, and create a commit/tag on postpublish.
-
-This does mean the Github repo will always be one patch commit off of what is published to NPM. Note that this will not affect functionality, and is only used to keep package management system files and the dist file version numbers in sync.
-
 Basic Setup
 ============
 Load the plugin CSS and JavaScript into your web page, and everything should work!
@@ -226,13 +222,18 @@ The following is a list of the commonly-used command line tasks:
 
 Version Bumping and Publishing (Maintainers Only)
 =======
-To bump the version number across all the various packagement systems the plugin is registered with, please use the [grunt bump](https://github.com/vojtajina/grunt-bump) plugin.
+To do the following release tasks:
+* bump the version
+* publish a new version to NPM
+* update the `gh-pages` branch
+* push a new `dist` bundle to the `master` branch on the remote `origin`
+* push new tags to the remote `origin`
 
-* _grunt bump:patch_ - patch version bump, __0.0.0 -> 0.0.1__
-* _grunt bump:minor_ - minor version bump, __0.0.0 -> 0.1.0__
-* _grunt bump:major_ - major version bump, __0.0.0 -> 1.0.0__
+Type the following command:
 
-After bumping, type `npm publish` to update on NPM.
+`npm run release <patch|minor|major>`
+
+If you do not specify a version bump type, the script will automatically defer to a patch bump.
 
 
 Other Platforms & Libraries

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "style": "dist/css/bootstrap-slider.css",
   "scripts": {
     "postpublish": "sh ./scripts/postpublish.sh",
-    "test": "grunt test"
+    "test": "grunt test",
+    "release": "sh ./scripts/release.sh"
   },
   "homepage": "http://github.com/seiyria/bootstrap-slider",
   "repository": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,13 +1,23 @@
 #!/bin/bash
 
-echo "Running postpublish script..."
+# Validate arguments
+versionBumpType=${1:-patch};
+
+if [ "$versionBumpType" != "major" ] && [ "$versionBumpType" != "minor" ] && [ "$versionBumpType" != "patch" ]; then
+  echo "Invalid version bump argument: ${versionBumpType}. Option must be one of the following: major, minor, patch"
+  exit 1
+else
+  echo "Publishing and bumping with ${versionBumpType} version bump"
+fi
+
+echo "Running version bump + publish script..."
 echo "."
 echo "."
-echo "Generating /dist and push to origin"
+echo "Generating /dist and push changes + tags to Github remote 'origin'"
 # Checkout master branch
 git checkout master
-# Version bump (patch)
-grunt bump-only:patch
+# Version bump
+grunt bump-only:"$versionBumpType"
 # Generate new dist
 grunt prod
 # Generate new index.html page
@@ -47,8 +57,16 @@ git push origin gh-pages:gh-pages -f
 # Switch back to master branch
 git checkout master
 
-# Notify that postpublish is complete
+## Publish to NPM
 echo "."
 echo "."
-echo "Postpublish script complete"
+echo "Publishing to NPM"
+echo "."
+echo "."
+npm publish
+
+# Notify script is complete
+echo "."
+echo "."
+echo "Script complete"
 echo ""


### PR DESCRIPTION
@seiyria 

I am attempting to refactor our release script a little bit.

One thing that always bothered me was the fact that we were always off by one patch bump when we published to npm.

So instead of having the version be bumped separately from the `gh-pages` build, `/dist` build, and `npm publish`, I figured we could just combine all of those into a script and then proxy it with the `npm run release` command. i tested it locally and it works great, but let me know what you think.

Thanks!