### PR TITLE
Namespace updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can see all of our API examples [here](http://seiyria.github.io/bootstrap-sl
 Using bootstrap-slider (with JQuery)
 ======================
 
+### Using `.slider` namespace
 Create an input element and call .slider() on it:
 
 ```js
@@ -48,6 +49,22 @@ var value = mySlider.slider('getValue');
 	mySlider
 		.slider('setValue', 5)
 		.slider('setValue', 7);
+```
+
+### Using `.bootstrapSlider` namespace
+Create an input element and call .bootstrapSlider() on it:
+
+```js
+// Instantiate a slider
+var mySlider = $("input.slider").bootstrapSlider();
+
+// Call a method on the slider
+var value = mySlider.bootstrapSlider('getValue');
+
+// For non-getter methods, you can chain together commands
+	mySlider
+		.bootstrapSlider('setValue', 5)
+		.bootstrapSlider('setValue', 7);
 ```
 
 Using bootstrap-slider (via `data-provide`-API)
@@ -74,7 +91,7 @@ turns it into a slider. Options can be supplied via `data-slider-` attributes.
 What if there is already a _slider_ plugin bound to the JQuery namespace?
 ======================
 
-If there is already a JQuery plugin named _slider_ bound to the JQuery namespace, then this plugin will take on the alternate namespace _bootstrapSlider_.
+If there is already a JQuery plugin named _slider_ bound to the JQuery namespace, then this plugin will emit a console warning telling you this namespace has already been taken and will encourage you to use the alternate namespace _bootstrapSlider_ instead.
 
 ```js
 // Instantiate a slider

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -49,6 +49,21 @@
 		window.Slider = factory(window.jQuery);
 	}
 }(function($) {
+	// Constants
+	const NAMESPACE_MAIN = 'slider';
+	const NAMESPACE_ALTERNATE = 'bootstrapSlider';
+
+	// Polyfill console methods
+	if (!window.console) {
+		window.console = {};
+	}
+	if (!window.console.log) {
+		window.console.log = function () { };
+	}
+	if (!window.console.warn) {
+		window.console.warn = function () { };
+	}
+
 	// Reference to Slider constructor
 	var Slider;
 
@@ -1641,12 +1656,21 @@
 
 		*********************************/
 		if($) {
-			var namespace = $.fn.slider ? 'bootstrapSlider' : 'slider';
-			$.bridget(namespace, Slider);
+			let autoRegisterNamespace;
+
+			if (!$.fn.slider) {
+				$.bridget(NAMESPACE_MAIN, Slider);
+				autoRegisterNamespace = NAMESPACE_MAIN;
+			}
+			else {
+				window.console.warn("bootstrap-slider.js - WARNING: $.fn.slider namespace is already bound. Use the $.fn.bootstrapSlider namespace instead.");
+				autoRegisterNamespace = NAMESPACE_ALTERNATE;
+			}
+			$.bridget(NAMESPACE_ALTERNATE, Slider);
 
 			// Auto-Register data-provide="slider" Elements
 			$(function() {
-				$("input[data-provide=slider]")[namespace]();
+				$("input[data-provide=slider]")[autoRegisterNamespace]();
 			});
 		}
 

--- a/test/specs/NamespaceSpec.js
+++ b/test/specs/NamespaceSpec.js
@@ -1,13 +1,7 @@
 describe("Namespace Tests", function() {
   var sourceJS = "temp/bootstrap-slider.js";
 
-  beforeEach(function() {
-    runs(function() {
-      $.fn.slider = function() {};
-    });
-  });
-
-  it("sets the plugin namespace to be 'bootstrapSlider' if $.fn.slider is already defined", function() {
+  it("should always set the plugin namespace to 'bootstrapSlider'", function() {
     var scriptLoaded;
 
     runs(function() {
@@ -22,6 +16,46 @@ describe("Namespace Tests", function() {
 
     runs(function() {
       expect($.fn.bootstrapSlider).toBeDefined();
+    });
+  });
+
+  it("should set the plugin namespace to 'slider' if the namespace is available", function() {
+    var scriptLoaded;
+
+    runs(function() {
+      $.getScript(sourceJS, function() {
+        scriptLoaded = true;
+      });
+    });
+
+    waitsFor(function() {
+      return scriptLoaded === true;
+    });
+
+    runs(function() {
+      expect($.fn.slider).toBeDefined();
+    });
+  });
+
+  it("should print a console warning if the 'slider' namespace is already bound", function() {
+    var scriptLoaded;
+
+    $.fn.slider = function() {};
+    spyOn(window.console, "warn");
+
+    runs(function() {
+      $.getScript(sourceJS, function() {
+        scriptLoaded = true;
+      });
+    });
+
+    waitsFor(function() {
+      return scriptLoaded === true;
+    });
+
+    runs(function() {
+      var expectedWarningMessage = "bootstrap-slider.js - WARNING: $.fn.slider namespace is already bound. Use the $.fn.bootstrapSlider namespace instead.";
+      expect(window.console.warn).toHaveBeenCalledWith(expectedWarningMessage);
     });
   });
 


### PR DESCRIPTION
Addresses: https://github.cleom/seiyria/bootstrap-slider/issues/575

After thinking about it more, I still want people to use the `$.fn.slider` namespace when possible, so I will not update the rest of the docs.

However, the plugin will always bind to the alternate namespace and will print a console warning when the main namespace is already reserved


Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [x] unit tests (we use [Jasmine 1.3](http://jasmine.github.io/1.3/introduction.html))
- [x] Link to original Github issue (if this is a bug-fix)
- [x] documentation updates to README file
- [x] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
