### PR TITLE
Fix crash in Chrome

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1656,7 +1656,7 @@
 
 		*********************************/
 		if($) {
-			let autoRegisterNamespace;
+			var autoRegisterNamespace;
 
 			if (!$.fn.slider) {
 				$.bridget(NAMESPACE_MAIN, Slider);


### PR DESCRIPTION
Chrome Version 47.0.2526.106 (64-bit) was throwing the following error:

	Uncaught SyntaxError: Block-scoped declarations (let, const,
	function, class) not yet supported outside strict mode

Firefox wasn't affected