### PR TITLE
Range highlights should reflect options.reversed when set

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1070,6 +1070,12 @@ const windowIsDefined = (typeof window === "object");
 						var startPercent = this._toPercentage(this.options.rangeHighlights[i].start);
 						var endPercent = this._toPercentage(this.options.rangeHighlights[i].end);
 
+						if (this.options.reversed) {
+							var sp = 100-endPercent;
+							endPercent = 100-startPercent;
+							startPercent = sp;
+						}
+
 						var currentRange = this._createHighlightRange(startPercent, endPercent);
 
 						if (currentRange) {

--- a/test/specs/RangeHighlightsSpec.js
+++ b/test/specs/RangeHighlightsSpec.js
@@ -82,6 +82,12 @@ describe("RangeHighlights Render Tests", function() {
 
         testSlider2.slider('destroy');
         testSlider2 = null;
+
+        testSlider3.slider('destroy');
+        testSlider3 = null;
+
+        testSlider4.slider('destroy');
+        testSlider4 = null;
     });
 
     //test the visibility of ranges e.g. : { "start": 23, "end": 15 } - out of range - not visible

--- a/test/specs/RangeHighlightsSpec.js
+++ b/test/specs/RangeHighlightsSpec.js
@@ -5,6 +5,8 @@
 describe("RangeHighlights Render Tests", function() {
     var testSlider1;
     var testSlider2;
+    var testSlider3;
+    var testSlider4;
 
     //setup
     beforeEach(function() {
@@ -34,6 +36,39 @@ describe("RangeHighlights Render Tests", function() {
                 { "start": 2, "end": 5 },   // top: 10%; height: 15%
                 { "start": 7, "end": 8 },   // top: 35%; height: 5%
                 { "start": 17, "end": 19 }, // top: 85%; height: 10%
+                { "start": 7, "end": -4 },  //out of range - not visible
+                { "start": 23, "end": 15 }  //out of range - not visible
+            ]
+        });
+
+        testSlider3 = $('#testSlider3').slider({
+            id: 'slider3',
+            min: 0,
+            max: 20,
+            step: 1,
+            value: 14,
+            reversed: true,
+            rangeHighlights: [
+                { "start": 2, "end": 5 },    // left: 75%; width: 15%
+                { "start": 7, "end": 8 },    // left: 60%; width: 5%
+                { "start": 17, "end": 19 },  // left: 5%; width: 10%
+                { "start": 17, "end": 24 },  //out of range - not visible
+                { "start": -3, "end": 19 }   //out of range - not visible
+            ]
+        });
+
+        testSlider4 = $('#testSlider4').slider({
+            id: 'slider4',
+            min: 0,
+            max: 20,
+            step: 1,
+            value: 14,
+            reversed: true,
+            orientation: 'vertical',
+            rangeHighlights: [
+                { "start": 2, "end": 5 },   // top: 75%; height: 15%
+                { "start": 7, "end": 8 },   // top: 60%; height: 5%
+                { "start": 17, "end": 19 }, // top: 5%; height: 10%
                 { "start": 7, "end": -4 },  //out of range - not visible
                 { "start": 23, "end": 15 }  //out of range - not visible
             ]
@@ -141,6 +176,48 @@ describe("RangeHighlights Render Tests", function() {
     }, {
         isVisible: false,
         start: '85%',
+        size: '10%'
+    }]);
+    testHighlightedElements('#slider3', true, [{
+        isVisible: true,
+        start: '75%',
+        size: '15%'
+    }, {
+        isVisible: true,
+        start: '60%',
+        size: '5%'
+    }, {
+        isVisible: true,
+        start: '5%',
+        size: '10%'
+    }, {
+        isVisible: false,
+        start: '5%',
+        size: '10%'
+    }, {
+        isVisible: false,
+        start: '5%',
+        size: '10%'
+    }]);
+    testHighlightedElements('#slider4', false, [{
+        isVisible: true,
+        start: '75%',
+        size: '15%'
+    }, {
+        isVisible: true,
+        start: '60%',
+        size: '5%'
+    }, {
+        isVisible: true,
+        start: '5%',
+        size: '10%'
+    }, {
+        isVisible: false,
+        start: '5%',
+        size: '10%'
+    }, {
+        isVisible: false,
+        start: '5%',
         size: '10%'
     }]);
 });

--- a/tpl/SpecRunner.tpl
+++ b/tpl/SpecRunner.tpl
@@ -33,8 +33,9 @@
 
 	<!-- Slider used for PublicMethodsSpec and EventsSpec -->
 	<input id="testSlider1" type="text"/>
-
 	<input id="testSlider2" type="text"/>
+	<input id="testSlider3" type="text"/>
+	<input id="testSlider4" type="text"/>
 
 	<!-- Note: Two input elements with class 'makeSlider' are required for tests to run properly -->
   <input class="makeSlider" type="text"/>


### PR DESCRIPTION
Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [x] unit tests (we use [Jasmine 1.3](http://jasmine.github.io/1.3/introduction.html))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) with new feature or bug-fix
- [ ] Link to original Github issue (if this is a bug-fix)
- [ ] documentation updates to README file
- [ ] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [x] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory