### PR TITLE
Validation fix to allow for string numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ __NOTE:__ Optional parameters are italicized.
 | Function | Parameters | Description |
 | -------- | ----------- | ----------- |
 | getValue | --- | Get the current value from the slider |
-| setValue | newValue, _triggerSlideEvent_, _triggerChangeEvent_ | Set a new value for the slider. If optional triggerSlideEvent parameter is _true_, 'slide' events will be triggered. If optional triggerChangeEvent parameter is _true_, 'change' events will be triggered. This function takes `newValue` as either a `Number` or `Array`.|
+| setValue | newValue, _triggerSlideEvent_, _triggerChangeEvent_ | Set a new value for the slider. If optional triggerSlideEvent parameter is _true_, 'slide' events will be triggered. If optional triggerChangeEvent parameter is _true_, 'change' events will be triggered. This function takes `newValue` as either a `Number`, `String`, `Array`. If the value is of type `String` it must be convertable to an integer or it will throw an error.|
 | getElement | --- | Get the div slider element |
 | destroy | --- | Properly clean up and remove the slider instance |
 | disable | ---| Disables the slider and prevents the user from changing the value |

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1651,13 +1651,13 @@ const windowIsDefined = (typeof window === "object");
 				return Math.max(0, Math.min(100, percentage));
 			},
 			_validateInputValue: function(val) {
-				if (typeof val === 'number') {
-					return val;
+				if (!isNaN(+val)) {
+					return +val;
 				} else if (Array.isArray(val)) {
 					this._validateArray(val);
 					return val;
 				} else {
-					throw new Error( ErrorMsgs.formatInvalidInputErrorMsg(val) );
+					throw new Error(ErrorMsgs.formatInvalidInputErrorMsg(val));
 				}
 			},
 			_validateArray: function(val) {

--- a/test/specs/PublicMethodsSpec.js
+++ b/test/specs/PublicMethodsSpec.js
@@ -254,19 +254,6 @@ describe("Public Method Tests", function() {
         expect(sliderValue).toBe(5);
       });
 
-      it('should throw an error if the slider is given a value it cannot convert to an int', function(){
-        var valueToSet = "fail";
-        var originalSliderValue = testSlider.slider('getValue');
-
-        var settingValue = function() {
-          testSlider.slider('setValue', valueToSet);
-        };
-        expect(settingValue).toThrow(new Error( formatInvalidInputMsg(valueToSet) ));
-
-        var sliderValue = testSlider.slider('getValue');
-        expect(sliderValue).toBe(originalSliderValue);
-      });
-
       it("if a value passed in is greater than the max (10), the slider only goes to the max", function() {
         var maxValue = 10,
             higherThanSliderMaxVal = maxValue + 5;

--- a/test/specs/PublicMethodsSpec.js
+++ b/test/specs/PublicMethodsSpec.js
@@ -254,6 +254,19 @@ describe("Public Method Tests", function() {
         expect(sliderValue).toBe(5);
       });
 
+      it('should throw an error if the slider is given a value it cannot convert to an int', function(){
+        var valueToSet = "fail";
+        var originalSliderValue = testSlider.slider('getValue');
+
+        var settingValue = function() {
+          testSlider.slider('setValue', valueToSet);
+        };
+        expect(settingValue).toThrow(new Error( formatInvalidInputMsg(valueToSet) ));
+
+        var sliderValue = testSlider.slider('getValue');
+        expect(sliderValue).toBe(originalSliderValue);
+      });
+
       it("if a value passed in is greater than the max (10), the slider only goes to the max", function() {
         var maxValue = 10,
             higherThanSliderMaxVal = maxValue + 5;

--- a/test/specs/PublicMethodsSpec.js
+++ b/test/specs/PublicMethodsSpec.js
@@ -173,7 +173,7 @@ describe("Public Method Tests", function() {
         var tooltipIsShownAfterSlide = $("#testSlider1").siblings(".slider").children("div.tooltip").hasClass("in");
         expect(tooltipIsShownAfterSlide).toBeTruthy();
       });
-      
+
       it("tooltip is shown on mouse over and hides correctly after mouse leave", function() {
         testSlider = $("#testSlider1").slider({
           tooltip : "show"
@@ -190,16 +190,16 @@ describe("Public Method Tests", function() {
         var tooltipIsShownAfterSlide = $("#testSlider1").siblings(".slider").children("div.tooltip").hasClass("in");
         expect(tooltipIsShownAfterSlide).toBeTruthy();
 
-        
+
         // Trigger leave
         var mouseleaveEvent = document.createEvent("Events");
         mouseleaveEvent.initEvent("mouseleave", true, true);
         testSlider.data('slider').sliderElem.dispatchEvent(mouseleaveEvent);
-        
+
         var tooltipIsAgainHidden = !($("#testSlider1").siblings(".slider").children("div.tooltip").hasClass("in"));
         expect(tooltipIsAgainHidden).toBeTruthy();
       });
-      
+
       it("tooltip is always shown if set to 'always'", function() {
         testSlider = $("#testSlider1").slider({
           tooltip : "always"
@@ -244,6 +244,14 @@ describe("Public Method Tests", function() {
 
         var sliderValue = testSlider.slider('getValue');
         expect(sliderValue).toBe(valueToSet);
+      });
+
+      it("properly sets the value of the slider when given a string value", function(){
+        var valueToSet = "5";
+        testSlider.slider('setValue', valueToSet);
+
+        var sliderValue = testSlider.slider('getValue');
+        expect(sliderValue).toBe(5);
       });
 
       it("if a value passed in is greater than the max (10), the slider only goes to the max", function() {
@@ -385,23 +393,23 @@ describe("Public Method Tests", function() {
         var testSlider = $("#testSlider1").slider({
           value : 3
         });
-  
+
           var newSliderVal = 5;
-  
+
           testSlider.on('slide', function(evt) {
             expect(newSliderVal).toEqual(evt.value);
           });
-  
+
         testSlider.slider('setValue', newSliderVal, true);
       });
 
       it("if triggerSlideEvent argument is false, the 'slide' event is not triggered", function() {
         var newSliderVal = 5;
-        var slideEventTriggered = false; 
+        var slideEventTriggered = false;
         var testSlider = $("#testSlider1").slider({
           value : 3
         });
-  
+
         testSlider.on('slide', function() {
           slideEventTriggered = true;
         });
@@ -416,22 +424,22 @@ describe("Public Method Tests", function() {
         var testSlider = $("#testSlider1").slider({
           value : 3
         });
-  
+
         var newSliderVal = 5;
 
         testSlider.on('change', function(evt) {
           expect(newSliderVal).toEqual(evt.value.newValue);
         });
-  
+
         testSlider.slider('setValue', newSliderVal, true);
       });
 
       it("if triggerChangeEvent argument is false, the 'change' event is not triggered", function() {
-        var changeEventTriggered = false; 
+        var changeEventTriggered = false;
         var testSlider = $("#testSlider1").slider({
           value : 3
         });
-  
+
         testSlider.on('change', function() {
           changeEventTriggered = true;
         });


### PR DESCRIPTION
# Pull Requests

Please accompany all pull requests with the following (where appropriate):
- [x] unit tests (we use [Jasmine 1.3](http://jasmine.github.io/1.3/introduction.html))
- [x] JSFiddle (plunker [link ](https://plnkr.co/edit/TRhGSSQu9yCluH7xDHNC?p=preview) [toggle the two files, new is update]
- [x] Fix for #630 
- [ ] documentation updates to README file
- [ ] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [x] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
