### PR TITLE
Prevent bootstrap modal hiding

### DIFF
--- a/dist/bootstrap-slider.js
+++ b/dist/bootstrap-slider.js
@@ -1411,7 +1411,7 @@ var windowIsDefined = (typeof window === "undefined" ? "undefined" : _typeof(win
 				this._setDataVal(newValue);
 				this.setValue(newValue, false, true);
 
-				ev.returnValue = false;
+				this._pauseEvent(ev);
 
 				if (this.options.focus) {
 					this._triggerFocusOnHandle(this._state.dragged);

--- a/dist/bootstrap-slider.js
+++ b/dist/bootstrap-slider.js
@@ -1411,7 +1411,7 @@ var windowIsDefined = (typeof window === "undefined" ? "undefined" : _typeof(win
 				this._setDataVal(newValue);
 				this.setValue(newValue, false, true);
 
-				this._pauseEvent(ev);
+				ev.returnValue = false;
 
 				if (this.options.focus) {
 					this._triggerFocusOnHandle(this._state.dragged);

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1453,7 +1453,7 @@ const windowIsDefined = (typeof window === "object");
 				this._setDataVal(newValue);
 				this.setValue(newValue, false, true);
 
-				this._pauseEvent(ev);
+				ev.returnValue = false;
 
 				if (this.options.focus) {
 					this._triggerFocusOnHandle(this._state.dragged);


### PR DESCRIPTION
Issue #339: Modal dialog closes when dragging and releasing mouse button outside dialog.
Bootstrap modal needs a mousedown event to check the modal needs to be closed. When you release the mouse, if mouse was on modal, there will be no exit. But in our situation bootstrap-slider prevents bubbling mousedown event to modal, so it closes when you finished mouse movement outside modal.

before:

![cameringo_20161214_013451](https://cloud.githubusercontent.com/assets/5712526/21162333/efe103ac-c19d-11e6-9373-b8aa6104bace.gif)

after:

![cameringo_20161214_013311](https://cloud.githubusercontent.com/assets/5712526/21162354/06b41204-c19e-11e6-9714-92ec8737f9a7.gif)
