### PR TITLE
Added Prefix + Suffix to Slider Value + Zero / Middle track alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,12 @@ Options can be passed either as a data (data-slider-foo) attribute, or as part o
 | orientation |	string | 'horizontal' |	set the orientation. Accepts 'vertical' or 'horizontal' |
 | value |	float,array |	5	| initial value. Use array to have a range slider. |
 | range |	bool |	false	| make range slider. Optional if initial value is an array. If initial value is scalar, max will be used for second value. |
-| selection |	string |	'before' |	selection placement. Accepts: 'before', 'after' or 'none'. In case of a range slider, the selection will be placed between the handles |
+| selection |	string |	'before' |	selection placement. Accepts: 'before', 'after', 'middle', 'zero' or 'none'. In case of a range slider, the selection will be placed between the handles |
 | tooltip |	string |	'show' |	whether to show the tooltip on drag, hide the tooltip, or always show the tooltip. Accepts: 'show', 'hide', or 'always' |
 | tooltip_split |	bool |	false |	if false show one tootip if true show two tooltips one for each handler |
 | tooltip_position |	string |	null |	Position of tooltip, relative to slider. Accepts 'top'/'bottom' for horizontal sliders and 'left'/'right' for vertically orientated sliders. Default positions are 'top' for horizontal and 'right' for vertical slider. |
+| tooltip_prefix |	string |	null |	Prefix to the Tooltip value. |
+| tooltip_suffix |	string |	null |	Suffix to the Tooltip value. |
 | handle |	string |	'round' |	handle shape. Accepts: 'round', 'square', 'triangle' or 'custom' |
 | reversed | bool | false | whether or not the slider should be reversed |
 | rtl | bool|string | 'auto' | whether or not the slider should be shown in rtl mode. Accepts true, false, 'auto'. Default 'auto' : use actual direction of HTML (`dir='rtl'`) |

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -857,6 +857,8 @@ const windowIsDefined = (typeof window === "object");
 				range: false,
 				selection: 'before',
 				tooltip: 'show',
+				tooltip_prefix: '',
+				tooltip_suffix: '',
 				tooltip_split: false,
 				handle: 'round',
 				reversed: false,
@@ -916,6 +918,10 @@ const windowIsDefined = (typeof window === "object");
 					this._addClass(this.handle2, 'hide');
 					if (this.options.selection === 'after') {
 						this._state.value[1] = this.options.max;
+					} else if (this.options.selection === 'middle') {
+						this._state.value[1] = (this.options.max + this.options.min) / 2;
+					} else if (this.options.selection === 'zero') {
+						this._state.value[1] = 0;
 					} else {
 						this._state.value[1] = this.options.min;
 					}
@@ -1145,7 +1151,7 @@ const windowIsDefined = (typeof window === "object");
 				this._state.over = false;
 			},
 			_setToolTipOnMouseOver: function _setToolTipOnMouseOver(tempState){
-				var formattedTooltipVal = this.options.formatter(!tempState ? this._state.value[0]: tempState.value[0]);
+				var formattedTooltipVal = this.options.tooltip_prefix + this.options.formatter(!tempState ? this._state.value[0]: tempState.value[0]) + this.options.tooltip_suffix;
 				var positionPercentages = !tempState ? getPositionPercentages(this._state, this.options.reversed) : getPositionPercentages(tempState, this.options.reversed);
 				this._setText(this.tooltipInner, formattedTooltipVal);
 
@@ -1321,7 +1327,7 @@ const windowIsDefined = (typeof window === "object");
 				var formattedTooltipVal;
 
 				if (this.options.range) {
-					formattedTooltipVal = this.options.formatter(this._state.value);
+					formattedTooltipVal = this.options.tooltip_prefix + this.options.formatter(this._state.value) + this.options.tooltip_suffix;
 					this._setText(this.tooltipInner, formattedTooltipVal);
 					this.tooltip.style[this.stylePos] = `${ (positionPercentages[1] + positionPercentages[0])/2 }%`;
 
@@ -1353,7 +1359,7 @@ const windowIsDefined = (typeof window === "object");
 						this._css(this.tooltip_max, `margin-${this.stylePos}`, `${ -this.tooltip_max.offsetWidth / 2 }px`);
 					}
 				} else {
-					formattedTooltipVal = this.options.formatter(this._state.value[0]);
+					formattedTooltipVal = this.options.tooltip_prefix + this.options.formatter(this._state.value[0]) + this.options.tooltip_suffix;
 					this._setText(this.tooltipInner, formattedTooltipVal);
 
 					this.tooltip.style[this.stylePos] = `${ positionPercentages[0] }%`;


### PR DESCRIPTION
Hi,

This PR adds two things
1. It adds the ability to add prefixes and [suffixes to the tooltip](http://i.imgur.com/iHBw347.png) (Which was required from the client)
2. Different alignment for the background track. ([Example with the track Middl'ed](http://i.imgur.com/iHBw347.png))

There hasn't been any unit tests added (which I'm happy to do, I'm just at work atm), and no JSFiddle, or templating. 

Happy to update those if you're interested in having these.
