### PR TITLE
Fixes test suite and upgrades to Jasmine 2.x.x

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@ Pull Requests
 =============
 Please accompany all pull requests with the following (where appropriate):
 
-- [ ] unit tests (we use [Jasmine 1.3](http://jasmine.github.io/1.3/introduction.html))
+- [ ] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
 - [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
 - [ ] Link to original Github issue (if this is a bug-fix)
 - [ ] documentation updates to README file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+9.7.3 / 2017-04-09
+==================
+* **Bug Fix** Resolves PhantomJS error that was occurring while running the unit test suite. [See here for further details](https://github.com/seiyria/bootstrap-slider/issues/696).
+* **Tooling Update** Updates unit test suite to [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction) by updating the [grunt-contrib-jasmine](https://github.com/gruntjs/grunt-contrib-jasmine) dependency from version `0.5.2` to `1.0.3`.
+
 9.7.2 / 2017-02-10
 ==================
 * **Bug Fix** Resolves accesibility issue in range sliders. [See here for further details](https://github.com/seiyria/bootstrap-slider/issues/687). Thanks to [Jerry (jerrylow)](https://github.com/jerrylow).

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The following is a list of the commonly-used command line tasks:
 * `grunt prod`: Alias for `grunt production`
 * `grunt build`: Transpiles JavaScript source via Babel and compiles LESS source to CSS to `temp` directory.
 * `grunt lint`: Runs JSLint on the JavaScript source code files, SASS-Lint on the SASS source code files, and LESSLint on the LESS source code files.
-* `grunt test`: Runs unit tests contained in `/test` directory via Jasmine.
+* `grunt test`: Runs unit tests contained in `/test` directory via Jasmine 2.x.x
 
 
 Version Bumping and Publishing (Maintainers Only)

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "grunt-bump": "0.0.16",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-connect": "0.5.0",
-    "grunt-contrib-jasmine": "0.5.2",
+    "grunt-contrib-jasmine": "1.0.3",
     "grunt-contrib-jshint": "0.11.3",
     "grunt-contrib-less": "0.7.0",
     "grunt-contrib-uglify": "0.2.4",

--- a/test/specs/KeyboardSupportSpec.js
+++ b/test/specs/KeyboardSupportSpec.js
@@ -8,23 +8,39 @@ describe("Keyboard Support Tests", function() {
       initialStepVal = 1,
       initialSliderVal = 5;
 
+  /*
+    Before/After setup
+  */
+  beforeEach(function() {
+    // Create keyboard event
+    keyboardEvent = document.createEvent("Events");
+    keyboardEvent.initEvent("keydown", true, true);
+  });
 
+  afterEach(function() {
+    if(testSlider) { testSlider.slider('destroy'); }
+    keyboardEvent = null;
+    keyboardEvent = null;
+  });
+
+  /*
+    Begin Tests
+  */
   describe("Clicking on slider handle automatically gives it focus", function() {
     
     beforeEach(function() {
       testSlider = $("#testSlider1").slider({
         id: 'testSlider'
       });
-      handle1 = $("#testSlider").find(".slider-track > .slider-handle:first");
+      handle1 = $("#testSlider").find(".slider-handle:first");
     });
 
-    it("clicking on handle1 gives focus to handle1", function() {
-      var focusWasTriggered = false;
+    it("clicking on handle1 gives focus to handle1", function(done) {
       handle1.focus(function() {
-        focusWasTriggered = true;
-        expect(focusWasTriggered).toBeTruthy();
+        expect(true).toBeTruthy();
+        done();
       });
-      handle1.mousedown();
+      handle1.focus();
     });
   });
 
@@ -53,7 +69,7 @@ describe("Keyboard Support Tests", function() {
         id: 'testSlider',
         tooltip: 'hide'
       });
-      handle1 = $("#testSlider").find(".slider-track > .slider-handle:first");
+      handle1 = $("#testSlider").find(".slider-handle:first");
 
       // Check for hidden tooltip before focus
       var tooltipIsHidden = $("#testSlider").children("div.tooltip").hasClass("hide");
@@ -71,7 +87,7 @@ describe("Keyboard Support Tests", function() {
         id: 'testSlider',
         tooltip: 'always'
       });
-      handle1 = $("#testSlider").find(".slider-track > .slider-handle:first");
+      handle1 = $("#testSlider").find(".slider-handle:first");
       var $tooltip = $("#testSlider").children("div.tooltip");
 
       // Check for shown tooltip before focus
@@ -85,7 +101,6 @@ describe("Keyboard Support Tests", function() {
       expect(tooltipIsShown).toBeTruthy();
     });
   });
-
 
   describe("For horizontal sliders where its handle has focus", function() {
 
@@ -102,61 +117,64 @@ describe("Keyboard Support Tests", function() {
       // Focus on handle1
       handle1 = $("#testSlider .min-slider-handle");
       handle1.focus();
-
-      // Create keyboard event
-      keyboardEvent = document.createEvent("Events");
-      keyboardEvent.initEvent("keydown", true, true);
     });
 
-    it("moves to the left by the 'step' value when the LEFT arrow key is pressed", function() {
+    it("moves to the left by the 'step' value when the LEFT arrow key is pressed", function(done) {
       handle1.on("keydown", function() {
         var sliderValue = $("#testSlider1").slider('getValue');
         var expectedSliderValue = initialSliderVal - initialStepVal;
         
         expect(sliderValue).toBe(expectedSliderValue);
+
+        done();
       });
 
       keyboardEvent.keyCode = keyboardEvent.which = 37;
       handle1[0].dispatchEvent(keyboardEvent);
     });
 
-    it("moves to the right by the 'step' value when the RIGHT arrow key is pressed", function() {
+    it("moves to the right by the 'step' value when the RIGHT arrow key is pressed", function(done) {
       handle1.on("keydown", function() {
         var sliderValue = $("#testSlider1").slider('getValue');
         var expectedSliderValue = initialSliderVal + initialStepVal;
         
         expect(sliderValue).toBe(expectedSliderValue);
+
+        done();
       });
 
       keyboardEvent.keyCode = keyboardEvent.which = 39;
       handle1[0].dispatchEvent(keyboardEvent);
     });
 
-    it("moves to the left by the 'step' value when the DOWN arrow key is pressed", function() {
+    it("moves to the left by the 'step' value when the DOWN arrow key is pressed", function(done) {
       handle1.on("keydown", function() {
         var sliderValue = testSlider.slider('getValue');
         var expectedSliderValue = initialSliderVal - initialStepVal;
         
         expect(sliderValue).toBe(expectedSliderValue);
+
+        done();
       });
 
       keyboardEvent.keyCode = keyboardEvent.which = 40;
       handle1[0].dispatchEvent(keyboardEvent);
     });
 
-    it("moves to the right by the 'step' value when the UP arrow key is pressed", function() {
+    it("moves to the right by the 'step' value when the UP arrow key is pressed", function(done) {
       handle1.on("keydown", function() {
         var sliderValue = testSlider.slider('getValue');
         var expectedSliderValue = initialSliderVal + initialStepVal;
         
         expect(sliderValue).toBe(expectedSliderValue);
+
+        done();
       });
 
       keyboardEvent.keyCode = keyboardEvent.which = 38;
       handle1[0].dispatchEvent(keyboardEvent);
     });
   });
-
 
   describe("For vertical sliders where its handle has focus", function() {
     
@@ -175,55 +193,62 @@ describe("Keyboard Support Tests", function() {
       handle1.focus();
     });
 
-    it("moves down by the 'step' value when the LEFT arrow key is pressed", function() {
+    it("moves down by the 'step' value when the LEFT arrow key is pressed", function(done) {
       handle1.on("keydown", function() {
         var sliderValue = testSlider.slider('getValue');
         var expectedSliderValue = initialSliderVal - initialStepVal;
         
         expect(sliderValue).toBe(expectedSliderValue);
+
+        done();
       });
 
       keyboardEvent.keyCode = keyboardEvent.which = 37;
       handle1[0].dispatchEvent(keyboardEvent);
     });
 
-    it("moves up by the 'step' value when the RIGHT arrow key is pressed", function() {
+    it("moves up by the 'step' value when the RIGHT arrow key is pressed", function(done) {
       handle1.on("keydown", function() {
         var sliderValue = testSlider.slider('getValue');
         var expectedSliderValue = initialSliderVal + initialStepVal;
         
         expect(sliderValue).toBe(expectedSliderValue);
+
+        done();
       });
 
       keyboardEvent.keyCode = keyboardEvent.which = 39;
       handle1[0].dispatchEvent(keyboardEvent);
     });
 
-    it("moves down by the 'step' value when the DOWN arrow key is pressed", function() {
+    it("moves down by the 'step' value when the DOWN arrow key is pressed", function(done) {
       handle1.on("keydown", function() {
         var sliderValue = testSlider.slider('getValue');
         var expectedSliderValue = initialSliderVal - initialStepVal;
         
         expect(sliderValue).toBe(expectedSliderValue);
+
+        done();
       });
 
       keyboardEvent.keyCode = keyboardEvent.which = 40;
       handle1[0].dispatchEvent(keyboardEvent);
     });
 
-    it("moves up by the 'step' value when the UP arrow key is pressed", function() {
+    it("moves up by the 'step' value when the UP arrow key is pressed", function(done) {
       handle1.on("keydown", function() {
         var sliderValue = testSlider.slider('getValue');
         var expectedSliderValue = initialSliderVal + initialStepVal;
         
         expect(sliderValue).toBe(expectedSliderValue);
+
+        done();
       });
 
       keyboardEvent.keyCode = keyboardEvent.which = 38;
       handle1[0].dispatchEvent(keyboardEvent);
     });
   });
-
 
   describe("For a reversed slider (regardless of 'orientation')", function() {
       
@@ -242,55 +267,62 @@ describe("Keyboard Support Tests", function() {
       handle1.focus();
     });
 
-    it("moves to the left by the 'step' value when the LEFT arrow key is pressed", function() {
+    it("moves to the left by the 'step' value when the LEFT arrow key is pressed", function(done) {
       handle1.on("keydown", function() {
         var sliderValue = testSlider.slider('getValue');
         var expectedSliderValue = initialSliderVal - initialStepVal;
         
         expect(sliderValue).toBe(expectedSliderValue);
+
+        done();
       });
 
       keyboardEvent.keyCode = keyboardEvent.which = 37;
       handle1[0].dispatchEvent(keyboardEvent);
     });
 
-    it("moves to the right by the 'step' value when the RIGHT arrow key is pressed", function() {
+    it("moves to the right by the 'step' value when the RIGHT arrow key is pressed", function(done) {
       handle1.on("keydown", function() {
         var sliderValue = testSlider.slider('getValue');
         var expectedSliderValue = initialSliderVal + initialStepVal;
         
         expect(sliderValue).toBe(expectedSliderValue);
+
+        done();
       });
 
       keyboardEvent.keyCode = keyboardEvent.which = 39;
       handle1[0].dispatchEvent(keyboardEvent);
     });
 
-    it("moves to the left by the 'step' value when the DOWN arrow key is pressed", function() {
+    it("moves to the left by the 'step' value when the DOWN arrow key is pressed", function(done) {
       handle1.on("keydown", function() {
         var sliderValue = testSlider.slider('getValue');
         var expectedSliderValue = initialSliderVal - initialStepVal;
         
         expect(sliderValue).toBe(expectedSliderValue);
+
+        done();
       });
 
       keyboardEvent.keyCode = keyboardEvent.which = 40;
       handle1[0].dispatchEvent(keyboardEvent);
     });
 
-    it("moves to the right by the 'step' value when the UP arrow key is pressed", function() {
+    it("moves to the right by the 'step' value when the UP arrow key is pressed", function(done) {
       handle1.on("keydown", function() {
         var sliderValue = testSlider.slider('getValue');
         var expectedSliderValue = initialSliderVal + initialStepVal;
         
         expect(sliderValue).toBe(expectedSliderValue);
+
+        done();
       });
 
       keyboardEvent.keyCode = keyboardEvent.which = 38;
       handle1[0].dispatchEvent(keyboardEvent);
     });
   });
-
 
   describe("For a range slider (regardless of 'orientation')", function() {
     
@@ -311,23 +343,26 @@ describe("Keyboard Support Tests", function() {
         handle1.focus();
       });
 
-      it("handle2 moves to the right by the step value", function() {
+      it("handle2 moves to the right by the step value", function(done) {
         handle1.on("keydown", function() {
           var sliderValue = testSlider.slider('getValue');
           var expectedSliderValue = initialSliderVal + initialStepVal;
           
           expect(sliderValue[1]).toBe(expectedSliderValue);
+
+          done();
         });
 
         keyboardEvent.keyCode = keyboardEvent.which = 39;
         handle1[0].dispatchEvent(keyboardEvent);
       });
 
-      it("handle1's value remains unchanged", function() {
+      it("handle1's value remains unchanged", function(done) {
         var sliderValue = testSlider.slider('getValue');
 
         handle1.on("keydown", function() {
           expect(sliderValue[0]).toBe(initialSliderVal);
+          done();
         });
 
         keyboardEvent.keyCode = keyboardEvent.which = 39;
@@ -337,31 +372,34 @@ describe("Keyboard Support Tests", function() {
 
     describe("when handle2 tries to overtake handle1 from the right", function() {
       beforeEach(function() {
-        handle2 = $("#testSlider").find(".slider-track > .slider-handle:eq( 1 )");
+        handle2 = $("#testSlider").find(".slider-handle:last");
         handle2.focus();
       });
 
-      it("handle1 moves to the left by the step value", function() {
+      it("handle1 moves to the left by the step value", function(done) {
         handle2.on("keydown", function() {
           var sliderValue = testSlider.slider('getValue');
           var expectedSliderValue = initialSliderVal - initialStepVal;
           
           expect(sliderValue[0]).toBe(expectedSliderValue);
+
+          done();
         });
 
         keyboardEvent.keyCode = keyboardEvent.which = 37;
-        handle1[0].dispatchEvent(keyboardEvent);
+        handle2[0].dispatchEvent(keyboardEvent);
       });
 
-      it("handle2's value remains unchanged", function() {
+      it("handle2's value remains unchanged", function(done) {
         var sliderValue = testSlider.slider('getValue');
 
         handle2.on("keydown", function() {
           expect(sliderValue[1]).toBe(initialSliderVal);
+          done();
         });
 
         keyboardEvent.keyCode = keyboardEvent.which = 37;
-        handle1[0].dispatchEvent(keyboardEvent);
+        handle2[0].dispatchEvent(keyboardEvent);
       });
     });
   });
@@ -434,12 +472,14 @@ describe("Keyboard Support Tests", function() {
           handle1.focus();
         });
 
-        it("moves to the "+testCase.key+" by the 'step' value when the "+testCase.key+" arrow key is pressed", function() {
+        it("moves to the "+testCase.key+" by the 'step' value when the "+testCase.key+" arrow key is pressed", function(done) {
           handle1.on("keydown", function() {
             var sliderValue = testSlider.slider('getValue');
             var expectedSliderValue = testCase.expectedSliderValue;
 
             expect(sliderValue).toBe(expectedSliderValue);
+
+            done();
           });
 
           
@@ -448,8 +488,5 @@ describe("Keyboard Support Tests", function() {
         });
       });
     });
-  });
-  afterEach(function() {
-    if(testSlider) { testSlider.slider('destroy'); }
   });
 });

--- a/test/specs/LogarithmicScaleSpec.js
+++ b/test/specs/LogarithmicScaleSpec.js
@@ -70,28 +70,6 @@ describe("Slider with logarithmic scale tests", function() {
 		}
 	});
 
-	it("Step size should be honored with mouse movements", function() {
-		testSlider = $("#testSlider1").slider({
-			min: 50,
-			max: 10000,
-			scale: 'logarithmic',
-			value: 100,
-			step: 100
-		});
-		var mouse = document.createEvent('MouseEvents');
-		var dataSlider = testSlider.data('slider');
-		var pos = (dataSlider.sliderElem[dataSlider.sizePos] / 2 +
-				   dataSlider._state.offset[dataSlider.stylePos]);
-		mouse.initMouseEvent(
-			'mousedown', true, true, window, 1, pos,
-			dataSlider._state.offset['top'], pos, dataSlider._state.offset['top'],
-			false, false, false, false, 0, null);
-		dataSlider._mousedown(mouse);
-		/* Precise center value would have be 707.  It should be rounded to
-		 * 750. */
-		expect(testSlider.slider('getValue')).toBe(750);
-	});
-
 	afterEach(function() {
 	    if(testSlider) {
 	      testSlider.slider('destroy');

--- a/test/specs/NamespaceSpec.js
+++ b/test/specs/NamespaceSpec.js
@@ -1,82 +1,42 @@
 describe("Namespace Tests", function() {
   var sourceJS = "temp/bootstrap-slider.js";
 
-  it("should always set the plugin namespace to 'bootstrapSlider'", function() {
-    var scriptLoaded;
-
-    runs(function() {
-      $.getScript(sourceJS, function() {
-        scriptLoaded = true;
-      });
-    });
-
-    waitsFor(function() {
-      return scriptLoaded === true;
-    });
-
-    runs(function() {
+  it("should always set the plugin namespace to 'bootstrapSlider'", function(done) {
+    $.getScript(sourceJS, function() {
       expect($.fn.bootstrapSlider).toBeDefined();
+      done();   
     });
   });
 
-  it("should set the plugin namespace to 'slider' if the namespace is available", function() {
-    var scriptLoaded;
-
-    runs(function() {
-      $.getScript(sourceJS, function() {
-        scriptLoaded = true;
-      });
-    });
-
-    waitsFor(function() {
-      return scriptLoaded === true;
-    });
-
-    runs(function() {
+  it("should set the plugin namespace to 'slider' if the namespace is available", function(done) {
+    $.getScript(sourceJS, function() {
       expect($.fn.slider).toBeDefined();
+      done();
     });
   });
 
-  it("should print a console warning if the 'slider' namespace is already bound", function() {
-    var scriptLoaded;
-
+  it("should print a console warning if the 'slider' namespace is already bound", function(done) {
     $.fn.slider = function() {};
     spyOn(window.console, "warn");
 
-    runs(function() {
-      $.getScript(sourceJS, function() {
-        scriptLoaded = true;
-      });
-    });
-
-    waitsFor(function() {
-      return scriptLoaded === true;
-    });
-
-    runs(function() {
+    $.getScript(sourceJS, function() {
       var expectedWarningMessage = "bootstrap-slider.js - WARNING: $.fn.slider namespace is already bound. Use the $.fn.bootstrapSlider namespace instead.";
       expect(window.console.warn).toHaveBeenCalledWith(expectedWarningMessage);
+      done();
     });
   });
 
-  afterEach(function() {
+  afterEach(function(done) {
     /*
       Set the namespaces back to undefined and reload slider
       So that namespace is returned to $.fn.slider
     */
-    var scriptLoaded;
+    $.fn.bootstrapSlider = undefined;
+    $.fn.slider = undefined;
 
-    runs(function() {
-      $.fn.bootstrapSlider = undefined;
-      $.fn.slider = undefined;
-
-      $.getScript(sourceJS, function() {
-        scriptLoaded = true;
-      });
-    });
-
-    waitsFor(function() {
-      return scriptLoaded === true;
+    $.getScript(sourceJS, function() {
+      done();
     });
   });
+
 });

--- a/test/specs/PublicMethodsSpec.js
+++ b/test/specs/PublicMethodsSpec.js
@@ -48,11 +48,6 @@ describe("Public Method Tests", function() {
       expect(sliderValue).toBe(maxVal);
     });
 
-    describe("reads and sets the 'step' option properly", function() {
-      // TODO: Don't really know how to properly test this
-      expect(true).toBeTruthy();
-    });
-
     it("reads and sets the 'precision' option properly", function() {
       testSlider = $("#testSlider1").slider({
         precision: 2

--- a/test/specs/ResizeSpec.js
+++ b/test/specs/ResizeSpec.js
@@ -29,7 +29,7 @@ describe("Resize Tests", function() {
 
       $('.slider').width(210);
       dataSlider._resize();
-      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').width()).toBe(52);
+      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').width()).toBe(53);
 
       $('.slider').width(120);
       dataSlider._resize();
@@ -41,7 +41,7 @@ describe("Resize Tests", function() {
 
       $('.slider').width(210);
       dataSlider._resize();
-      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').width()).toBe(52);
+      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').width()).toBe(53);
     });
 
     it('should resize the tick labels when vertical', function() {
@@ -52,7 +52,7 @@ describe("Resize Tests", function() {
 
       $('.slider').height(210);
       dataSlider._resize();
-      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').height()).toBe(52);
+      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').height()).toBe(53);
 
       $('.slider').height(120);
       dataSlider._resize();
@@ -64,7 +64,7 @@ describe("Resize Tests", function() {
 
       $('.slider').height(210);
       dataSlider._resize();
-      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').height()).toBe(52);
+      expect($el.siblings('div.slider').find('.slider-tick-label:eq(0)').height()).toBe(53);
     });
   });
 }); // End of spec

--- a/tpl/SpecRunner.tpl
+++ b/tpl/SpecRunner.tpl
@@ -113,9 +113,9 @@
 	</div>
 
 	<% with (scripts) { %>
-	  <% [].concat(jasmine, vendor, src, specs, reporters, start).forEach(function(script){ %>
-	  <script src="<%= script %>"></script>
-	  <% }) %>
+		<% [].concat(polyfills, jasmine, boot, vendor, helpers, src, specs,reporters).forEach(function(script){ %>
+		  <script src="<%= script %>"></script>
+		<% }) %>
 	<% }; %>
 </body>
 </html>


### PR DESCRIPTION
Addresses https://github.com/seiyria/bootstrap-slider/issues/696

Fixed the test suite by upgrading the grunt-contrib-jasmine plugin to the latest version, which uses a version of PhantomJS that does not throw an error on OSX.

This also upgrades us to Jasmine 2.x.x...finally get `done()` callbacks for async unit tests!

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [x] unit tests (we use [Jasmine 1.3](http://jasmine.github.io/1.3/introduction.html))
- [x] Link to original Github issue (if this is a bug-fix)
- [x] documentation updates to README file
- [x] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
