### PR TITLE
Added link to Vue.js bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Other Platforms & Libraries
 - [NuGet](https://www.nuget.org/packages/bootstrap-slider/) ([@ChrisMissal](https://github.com/ChrisMissal))
 - [MeteorJS](https://github.com/kidovate/meteor-bootstrap-slider)
 - [Maven](http://mvnrepository.com/artifact/org.webjars.bower/seiyria-bootstrap-slider)
+- [Vue.js](https://github.com/pimlie/vue-bootstrap-slider) ([@pimlie](https://github.com/pimlie))
 
 Maintainers
 ============


### PR DESCRIPTION
I have created Vue.js bindings so Vue.js users can also easily use the `bootstrap-slider` without too much efforts