### PR TITLE
switched to using variables for the colors

### DIFF
--- a/src/less/rules.less
+++ b/src/less/rules.less
@@ -27,7 +27,7 @@
 				border-width: 0 (@slider-line-height/2) (@slider-line-height/2) (@slider-line-height/2);
 				width: 0;
 				height: 0;
-				border-bottom-color: #0480be;
+				border-bottom-color: @slider-primary-bottom;
 				margin-top: 0;
 			}
 		}
@@ -91,8 +91,8 @@
 				border-width: (@slider-line-height/2) 0 (@slider-line-height/2) (@slider-line-height/2);
 				width: 1px;
 				height: 1px;
-				border-left-color: #0480be;
-				border-right-color: #0480be;
+				border-left-color: @slider-primary-bottom;
+				border-right-color: @slider-primary-bottom;
 				margin-left: 0;
 				margin-right: 0;
 			}
@@ -130,10 +130,10 @@
 	}
 	&.slider-disabled {
 		.slider-handle {
-			#gradient > .vertical(#dfdfdf, #bebebe);
+			#gradient > .vertical(@slider-gray-2, @slider-gray-1);
 		}
 		.slider-track {
-			#gradient > .vertical(#e5e5e5, #e9e9e9);
+			#gradient > .vertical(@slider-gray-3, @slider-gray-4);
 			cursor: not-allowed;
 		}
 	}
@@ -156,19 +156,19 @@
 .slider-track {
 	position: absolute;
 	cursor: pointer;
-	#gradient > .vertical(#f5f5f5, #f9f9f9);
+	#gradient > .vertical(@slider-gray-5, @slider-gray-6);
 	.box-shadow(inset 0 1px 2px rgba(0,0,0,.1));
 	border-radius: @border-radius-base;
 }
 .slider-selection {
 	position: absolute;
-	#gradient > .vertical(#f9f9f9, #f5f5f5);
+	#gradient > .vertical(@slider-gray-6, @slider-gray-5);
 	.box-shadow(inset 0 -1px 0 rgba(0,0,0,.15));
 	.box-sizing(border-box);
 	border-radius: @border-radius-base;
 }
 .slider-selection.tick-slider-selection {
-	#gradient > .vertical(#89cdef, #81bfde);
+	#gradient > .vertical(@slider-secondary-top, @slider-secondary-bottom);
 }
 .slider-track-low, .slider-track-high {
 	position: absolute;
@@ -181,8 +181,8 @@
 	top: 0;
 	width: @slider-line-height;
 	height: @slider-line-height;
-	background-color: #337ab7;
-	#gradient > .vertical(#149bdf, #0480be);
+	background-color: @slider-primary;
+	#gradient > .vertical(@slider-primary-top, @slider-primary-bottom);
 	filter: none;
 	.box-shadow(~"inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05)");
 	border: 0px solid transparent;
@@ -198,7 +198,7 @@
 			line-height: @slider-line-height;
 			font-size: 20px;
 			content: '\2605'; //unicode star character
-			color: #726204;
+			color: @slider-unicode-color;
 		}
 	}
 }
@@ -206,7 +206,7 @@
 	position: absolute;
 	width: @slider-line-height;
 	height: @slider-line-height;
-	#gradient.vertical(#f9f9f9, #f5f5f5);
+	#gradient.vertical(@slider-gray-6, @slider-gray-5);
 	.box-shadow(inset 0 -1px 0 rgba(0,0,0,.15));
 	.box-sizing(border-box);
 	filter: none;
@@ -224,11 +224,11 @@
 			line-height: @slider-line-height;
 			font-size: 20px;
 			content: '\2605'; //unicode star character
-			color: #726204;
+			color: @slider-unicode-color;
 		}
 	}
 	&.in-selection {
-		#gradient > .vertical(#89cdef, #81bfde);
+		#gradient > .vertical(@slider-secondary-top, @slider-secondary-bottom);
 		opacity: 1;
 	}
 }

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -1,3 +1,22 @@
 @slider-line-height: @line-height-computed;
 @slider-horizontal-width: 210px;
 @slider-vertical-height: 210px;
+
+// Primary colors
+// @brand-primary is set in ../../node_modules/bootstrap/less/variables.less and evaluates to #337ab7
+@slider-primary: @brand-primary;
+@slider-primary-top: @slider-primary;
+@slider-primary-bottom: darken(@slider-primary, 5%);
+@slider-secondary-top: saturate(lighten(@slider-primary, 28%), 20%);
+@slider-secondary-bottom: saturate(lighten(@slider-primary, 23%), 2%);
+
+// grays for slider channel and disabled states
+@slider-gray-1: #bebebe;
+@slider-gray-2: #dfdfdf;
+@slider-gray-3: #e5e5e5;
+@slider-gray-4: #e9e9e9;
+@slider-gray-5: #f5f5f5;
+@slider-gray-6: #f9f9f9;
+
+// unicode color for demo page
+@slider-unicode-color: #726204;

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -11,12 +11,12 @@
 @slider-secondary-bottom: saturate(lighten(@slider-primary, 23%), 2%);
 
 // grays for slider channel and disabled states
-@slider-gray-1: #bebebe;
-@slider-gray-2: #dfdfdf;
-@slider-gray-3: #e5e5e5;
-@slider-gray-4: #e9e9e9;
-@slider-gray-5: #f5f5f5;
-@slider-gray-6: #f9f9f9;
+@slider-gray-1: #BEBEBE;
+@slider-gray-2: #DFDFDF;
+@slider-gray-3: #E5E5E5;
+@slider-gray-4: #E9E9E9;
+@slider-gray-5: #F5F5F5;
+@slider-gray-6: #F9F9F9;
 
 // unicode color for demo page
 @slider-unicode-color: #726204;

--- a/src/sass/_rules.scss
+++ b/src/sass/_rules.scss
@@ -27,7 +27,7 @@
         border-width: 0 $slider-line-height/2 $slider-line-height/2 $slider-line-height/2;
         width: 0;
         height: 0;
-        border-bottom-color: #0480BE;
+        border-bottom-color: $slider-primary-bottom;
         margin-top: 0;
       }
     }
@@ -90,7 +90,7 @@
         border-width: $slider-line-height/2 0 $slider-line-height/2 $slider-line-height/2;
         width:  1px;
         height: 1px;
-        border-left-color: #0480BE;
+        border-left-color: $slider-primary-bottom;
         margin-left: 0;
       }
     }
@@ -125,10 +125,10 @@
   }
   &.slider-disabled {
     .slider-handle {
-      @include slider_background-image(#DFDFDF, #BEBEBE, #F7F7F7);
+      @include slider_background-image($slider-gray-2, $slider-gray-1, mix($slider-gray-2, $slider-gray-1));
     }
     .slider-track {
-      @include slider_background-image(#E5E5E5, #E9E9E9, #F7F7F7);
+      @include slider_background-image($slider-gray-3, $slider-gray-4, mix($slider-gray-3, $slider-gray-4));
       cursor: not-allowed;
     }
   }
@@ -156,7 +156,7 @@
 }
 
 .slider-track {
-  @include slider_background-image(#F5F5F5, #F9F9F9, #F7F7F7);
+  @include slider_background-image($slider-gray-5, $slider-gray-6, mix($slider-gray-5, $slider-gray-6));
   @include slider_box-shadow(inset 0 1px 2px rgba(0,0,0,0.1));
   @include slider_border-radius($slider-border-radius);
 
@@ -165,7 +165,7 @@
 }
 
 .slider-selection {
-  @include slider_background-image(#F9F9F9, #F5F5F5, #F7F7F7);
+  @include slider_background-image($slider-gray-6, $slider-gray-5, mix($slider-gray-6, $slider-gray-5));
   @include slider_box-shadow(inset 0 -1px 0 rgba(0,0,0,0.15));
   @include slider_box-sizing(border-box);
   @include slider_border-radius($slider-border-radius);
@@ -173,7 +173,7 @@
   position: absolute;
 }
 .slider-selection.tick-slider-selection {
-  @include slider_background-image(#89CDEF, #81BFDE, #F7F7F7);
+  @include slider_background-image($slider-secondary-top, $slider-secondary-bottom, mix($slider-secondary-top, $slider-secondary-bottom));
 }
 
 .slider-track-low, .slider-track-high {
@@ -185,14 +185,14 @@
 }
 
 .slider-handle {
-  @include slider_background-image(#149BDF, #0480BE, #0E90D2);
+  @include slider_background-image($slider-primary-top, $slider-primary-bottom, mix($slider-primary-top, $slider-primary-bottom));
   @include slider_box-shadow(inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05));
 
   position: absolute;
   top: 0;
   width:  $slider-line-height;
   height: $slider-line-height;
-  background-color: #337AB7;
+  background-color: $slider-primary;
   border: 0px solid transparent;
 
   &.round {
@@ -207,13 +207,13 @@
       line-height: $slider-line-height;
       font-size: 20px;
       content: '\2605'; //unicode star character
-      color: #726204;
+      color: $slider-unicode-color;
     }
   }
 }
 
 .slider-tick {
-  @include slider_background-image(#F9F9F9, #F5F5F5, #F7F7F7);
+  @include slider_background-image($slider-gray-5, $slider-gray-6, mix($slider-gray-5, $slider-gray-6));
   @include slider_box-shadow(inset 0 -1px 0 rgba(0,0,0,0.15));
   @include slider_box-sizing(border-box);
 
@@ -236,11 +236,11 @@
       line-height: $slider-line-height;
       font-size: 20px;
       content: '\2605'; //unicode star character
-      color: #726204;
+      color: $slider-unicode-color;
     }
   }
   &.in-selection {
-    @include slider_background-image(#89CDEF, #81BFDE, #F7F7F7);
+    @include slider_background-image($slider-secondary-top, $slider-secondary-bottom, mix($slider-secondary-top, $slider-secondary-bottom));
     opacity: 1;
   }
 }

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -8,7 +8,7 @@ $slider-primary: null !default;
 @if variable-exists(brand-primary) {
   $slider-primary: $brand-primary !default;
 } @else {
-  $slider-primary: #0480be !default;
+  $slider-primary: #0480BE !default;
 }
 
 $slider-primary-top: $slider-primary !default;
@@ -17,12 +17,12 @@ $slider-secondary-top: saturate(lighten($slider-primary, 28%), 20%) !default;
 $slider-secondary-bottom: saturate(lighten($slider-primary, 23%), 2%) !default;
 
 // grays for slider channel and disabled states
-$slider-gray-1: #bebebe !default;
-$slider-gray-2: #dfdfdf !default;
-$slider-gray-3: #e5e5e5 !default;
-$slider-gray-4: #e9e9e9 !default;
-$slider-gray-5: #f5f5f5 !default;
-$slider-gray-6: #f9f9f9 !default;
+$slider-gray-1: #BEBEBE !default;
+$slider-gray-2: #DFDFDF !default;
+$slider-gray-3: #E5E5E5 !default;
+$slider-gray-4: #E9E9E9 !default;
+$slider-gray-5: #F5F5F5 !default;
+$slider-gray-6: #F9F9F9 !default;
 
 // unicode color for demo page
 $slider-unicode-color: #726204 !default;

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -2,3 +2,27 @@ $slider-line-height: 20px !default;
 $slider-border-radius: 4px !default;
 $slider-horizontal-width: 210px !default;
 $slider-vertical-height: 210px !default;
+
+// Primary colors
+$slider-primary: null !default;
+@if variable-exists(brand-primary) {
+  $slider-primary: $brand-primary !default;
+} @else {
+  $slider-primary: #0480be !default;
+}
+
+$slider-primary-top: $slider-primary !default;
+$slider-primary-bottom: darken($slider-primary, 5%) !default;
+$slider-secondary-top: saturate(lighten($slider-primary, 28%), 20%) !default;
+$slider-secondary-bottom: saturate(lighten($slider-primary, 23%), 2%) !default;
+
+// grays for slider channel and disabled states
+$slider-gray-1: #bebebe !default;
+$slider-gray-2: #dfdfdf !default;
+$slider-gray-3: #e5e5e5 !default;
+$slider-gray-4: #e9e9e9 !default;
+$slider-gray-5: #f5f5f5 !default;
+$slider-gray-6: #f9f9f9 !default;
+
+// unicode color for demo page
+$slider-unicode-color: #726204 !default;


### PR DESCRIPTION
Pull Request Referencing #778 
=============

Requesting pull for branch that uses variables in place of hardcoded values for the control colors.  Additionally, brand-primary is used.  bootstrap variables file is already a dependency of bootstrap-slider.less by use of `@line-height-computed` in variables.less, so that just uses the `@brand-primary` variable.  For the SASS file, it either uses the `$brand-primary` variable if it exists or it uses a default of `#0480be`.

Feel free to tweak the colors as needed.  Otherwise, if they need adjusted, I can make the changes in another commit too.