### PR TITLE
Use `transform: translate()` instead of margin-* for the tooltips. Fix #483

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -651,9 +651,6 @@ const windowIsDefined = (typeof window === "object");
 					this._removeProperty(tooltip, 'left');
 					this._removeProperty(tooltip, 'right');
 					this._removeProperty(tooltip, 'top');
-					this._removeProperty(tooltip, 'margin-left');
-					this._removeProperty(tooltip, 'margin-right');
-					this._removeProperty(tooltip, 'margin-top');
 
 					this._removeClass(tooltip, 'right');
 					this._removeClass(tooltip, 'left');
@@ -1153,11 +1150,6 @@ const windowIsDefined = (typeof window === "object");
 				this._setText(this.tooltipInner, formattedTooltipVal);
 
 				this.tooltip.style[this.stylePos] = `${positionPercentages[0]}%`;
-				if (this.options.orientation === 'vertical') {
-					this._css(this.tooltip, `margin-${this.stylePos}`, `${-this.tooltip.offsetHeight / 2}px`);
-				} else {
-					this._css(this.tooltip, `margin-${this.stylePos}`, `${-this.tooltip.offsetWidth / 2}px`);
-				}
 
 				function getPositionPercentages(state, reversed){
 					if (reversed) {
@@ -1322,17 +1314,18 @@ const windowIsDefined = (typeof window === "object");
 				}
 
 				var formattedTooltipVal;
+				var tooltip_translation;
+				if (this.options.orientation === 'vertical') {
+					tooltip_translation = `translateY(-50%)`;
+				} else {
+					tooltip_translation = `translateX(` + (this.stylePos === "left" ? "-" : "+") + `50%)`;
+				}
 
 				if (this.options.range) {
 					formattedTooltipVal = this.options.formatter(this._state.value);
 					this._setText(this.tooltipInner, formattedTooltipVal);
 					this.tooltip.style[this.stylePos] = `${ (positionPercentages[1] + positionPercentages[0])/2 }%`;
-
-					if (this.options.orientation === 'vertical') {
-						this._css(this.tooltip, `margin-${this.stylePos}`, `${ -this.tooltip.offsetHeight / 2 }px`);
-					} else {
-						this._css(this.tooltip, `margin-${this.stylePos}`, `${ -this.tooltip.offsetWidth / 2 }px`);
-					}
+					this._css(this.tooltip, `transform`, tooltip_translation);
 
 					var innerTooltipMinText = this.options.formatter(this._state.value[0]);
 					this._setText(this.tooltipInner_min, innerTooltipMinText);
@@ -1341,30 +1334,17 @@ const windowIsDefined = (typeof window === "object");
 					this._setText(this.tooltipInner_max, innerTooltipMaxText);
 
 					this.tooltip_min.style[this.stylePos] = `${ positionPercentages[0] }%`;
-
-					if (this.options.orientation === 'vertical') {
-						this._css(this.tooltip_min, `margin-${this.stylePos}`, `${ -this.tooltip_min.offsetHeight / 2  }px`);
-					} else {
-						this._css(this.tooltip_min, `margin-${this.stylePos}`, `${ -this.tooltip_min.offsetWidth / 2  }px`);
-					}
+					this._css(this.tooltip_min, `transform`, tooltip_translation);
 
 					this.tooltip_max.style[this.stylePos] = `${ positionPercentages[1] }%`;
 
-					if (this.options.orientation === 'vertical') {
-						this._css(this.tooltip_max, `margin-${this.stylePos}`, `${ -this.tooltip_max.offsetHeight / 2 }px`);
-					} else {
-						this._css(this.tooltip_max, `margin-${this.stylePos}`, `${ -this.tooltip_max.offsetWidth / 2 }px`);
-					}
+					this._css(this.tooltip_max, `transform`, tooltip_translation);
 				} else {
 					formattedTooltipVal = this.options.formatter(this._state.value[0]);
 					this._setText(this.tooltipInner, formattedTooltipVal);
 
 					this.tooltip.style[this.stylePos] = `${ positionPercentages[0] }%`;
-					if (this.options.orientation === 'vertical') {
-						this._css(this.tooltip, `margin-${this.stylePos}`, `${ -this.tooltip.offsetHeight / 2 }px`);
-					} else {
-						this._css(this.tooltip, `margin-${this.stylePos}`, `${ -this.tooltip.offsetWidth / 2 }px`);
-					}
+					this._css(this.tooltip, `transform`, tooltip_translation);
 				}
 
 				if (this.options.orientation === 'vertical') {

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1314,18 +1314,11 @@ const windowIsDefined = (typeof window === "object");
 				}
 
 				var formattedTooltipVal;
-				var tooltip_translation;
-				if (this.options.orientation === 'vertical') {
-					tooltip_translation = `translateY(-50%)`;
-				} else {
-					tooltip_translation = `translateX(` + (this.stylePos === "left" ? "-" : "+") + `50%)`;
-				}
 
 				if (this.options.range) {
 					formattedTooltipVal = this.options.formatter(this._state.value);
 					this._setText(this.tooltipInner, formattedTooltipVal);
 					this.tooltip.style[this.stylePos] = `${ (positionPercentages[1] + positionPercentages[0])/2 }%`;
-					this._css(this.tooltip, `transform`, tooltip_translation);
 
 					var innerTooltipMinText = this.options.formatter(this._state.value[0]);
 					this._setText(this.tooltipInner_min, innerTooltipMinText);
@@ -1334,17 +1327,14 @@ const windowIsDefined = (typeof window === "object");
 					this._setText(this.tooltipInner_max, innerTooltipMaxText);
 
 					this.tooltip_min.style[this.stylePos] = `${ positionPercentages[0] }%`;
-					this._css(this.tooltip_min, `transform`, tooltip_translation);
 
 					this.tooltip_max.style[this.stylePos] = `${ positionPercentages[1] }%`;
 
-					this._css(this.tooltip_max, `transform`, tooltip_translation);
 				} else {
 					formattedTooltipVal = this.options.formatter(this._state.value[0]);
 					this._setText(this.tooltipInner, formattedTooltipVal);
 
 					this.tooltip.style[this.stylePos] = `${ positionPercentages[0] }%`;
-					this._css(this.tooltip, `transform`, tooltip_translation);
 				}
 
 				if (this.options.orientation === 'vertical') {

--- a/src/less/rules.less
+++ b/src/less/rules.less
@@ -23,6 +23,7 @@
 			&.triangle {
 				position: relative;
 				top: 50%;
+				-ms-transform: translateY(-50%);
 				transform: translateY(-50%);
 				border-width: 0 (@slider-line-height/2) (@slider-line-height/2) (@slider-line-height/2);
 				width: 0;
@@ -48,6 +49,10 @@
 				text-align: center;
 			}
 		}
+		.tooltip {
+			-ms-transform: translateX(-50%);
+			transform: translateX(-50%);
+		}
 		&.slider-rtl {
 			.slider-track {
 				left: initial;
@@ -61,6 +66,10 @@
 			.slider-tick-container {
 				left: initial;
 				right: 0;
+			}
+			.tooltip {
+				-ms-transform: translateX(+50%);
+				transform: translateX(+50%);
 			}
 		}
 	}
@@ -104,7 +113,10 @@
 				padding-left: @slider-line-height * .2;
 			}
 		}
-
+		.tooltip {
+			-ms-transform: translateY(-50%);
+			transform: translateY(-50%);
+		}
 		&.slider-rtl {
 			.slider-track {
 				left: initial;

--- a/test/specs/PublicMethodsSpec.js
+++ b/test/specs/PublicMethodsSpec.js
@@ -582,6 +582,28 @@ describe("Public Method Tests", function() {
     expect(orientationClassApplied).toBeTruthy();
   });
 
+  it("relayout: if slider is not displayed on initialization and then displayed later on, relayout() will not adjust the margin-left of the tooltip", function() {
+    // Setup
+    testSlider = new Slider("#relayoutSliderInput", {
+      id: "relayoutSlider",
+      min: 0,
+      max: 10,
+      value: 5
+    });
+    var mainTooltipDOMRef = document.querySelector("#relayoutSlider .tooltip-main");
+    var relayoutSliderContainerDOMRef = document.querySelector("#relayoutSliderContainer");
+    var tooltipMarginLeft;
+    // Main tooltip margin-left offset should not be set on slider intialization
+    tooltipMarginLeft = parseFloat(mainTooltipDOMRef.style.marginLeft);
+    expect(tooltipMarginLeft).toBeNaN();
+    // Show slider and call relayout()
+    relayoutSliderContainerDOMRef.style.display = "block";
+    testSlider.relayout();
+    // Main tooltip margin-left offset should not be set after relayout() is called.
+    tooltipMarginLeft = Math.abs( parseFloat(mainTooltipDOMRef.style.marginLeft) );
+    expect(tooltipMarginLeft).toBeNaN();
+  });
+
   it("relayout: if slider is not displayed on initialization and then displayed later on, relayout() will re-adjust the tick label width", function() {
     // Setup
     testSlider = new Slider("#relayoutSliderInputTickLabels", {

--- a/test/specs/PublicMethodsSpec.js
+++ b/test/specs/PublicMethodsSpec.js
@@ -582,28 +582,6 @@ describe("Public Method Tests", function() {
     expect(orientationClassApplied).toBeTruthy();
   });
 
-  it("relayout: if slider is not displayed on initialization and then displayed later on, relayout() will re-adjust the margin-left of the tooltip", function() {
-    // Setup
-    testSlider = new Slider("#relayoutSliderInput", {
-      id: "relayoutSlider",
-      min: 0,
-      max: 10,
-      value: 5
-    });
-    var mainTooltipDOMRef = document.querySelector("#relayoutSlider .tooltip-main");
-    var relayoutSliderContainerDOMRef = document.querySelector("#relayoutSliderContainer");
-    var tooltipMarginLeft;
-    // Main tooltip margin-left offset should be 0 on slider intialization
-    tooltipMarginLeft = parseFloat(mainTooltipDOMRef.style.marginLeft);
-    expect(tooltipMarginLeft).toBe(0);
-    // Show slider and call relayout()
-    relayoutSliderContainerDOMRef.style.display = "block";
-    testSlider.relayout();
-    // Main tooltip margin-left offset should re-adjust to be > 0
-    tooltipMarginLeft = Math.abs( parseFloat(mainTooltipDOMRef.style.marginLeft) );
-    expect(tooltipMarginLeft).toBeGreaterThan(0);
-  });
-
   it("relayout: if slider is not displayed on initialization and then displayed later on, relayout() will re-adjust the tick label width", function() {
     // Setup
     testSlider = new Slider("#relayoutSliderInputTickLabels", {


### PR DESCRIPTION
Fix #483 using CSS property `transform` instead of `margin-*` for the tooltips.

According to [caniuse.com](http://caniuse.com/#search=transform), this property has a very good support in the browsers.