### PR TITLE
introduce bs_version option for bs4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Options can be passed either as a data (data-slider-foo) attribute, or as part o
 | focus | bool | false | Focus the appropriate slider handle after a value change. |
 | labelledby | string,array | null | ARIA labels for the slider handle's, Use array for multiple values in a range slider. |
 | rangeHighlights | array | [] | Defines a range array that you want to highlight, for example: [{'start':val1, 'end': val2, 'class': 'optionalAdditionalClassName'}]. |
+| bsVersion | string | 'bs3' | Switch between Boostrap 3 ('bs3') and Bootstrap 4 ('bs4') |
 
 Functions
 =========

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -647,14 +647,15 @@ const windowIsDefined = (typeof window === "object");
 				}, this);
 
 				// Undo inline styles and classes on tooltips
+				const positionClasses = this._getTooltipPositionClassMap();
 				[this.tooltip, this.tooltip_min, this.tooltip_max].forEach(function(tooltip) {
 					this._removeProperty(tooltip, 'left');
 					this._removeProperty(tooltip, 'right');
 					this._removeProperty(tooltip, 'top');
 
-					this._removeClass(tooltip, 'right');
-					this._removeClass(tooltip, 'left');
-					this._removeClass(tooltip, 'top');
+					this._removeClass(tooltip, positionClasses.right);
+					this._removeClass(tooltip, positionClasses.left);
+					this._removeClass(tooltip, positionClasses.top);
 				}, this);
 			}
 
@@ -879,7 +880,8 @@ const windowIsDefined = (typeof window === "object");
 				focus: false,
 				tooltip_position: null,
 				labelledby: null,
-				rangeHighlights: []
+				rangeHighlights: [],
+				bsVersion: 'bs3'
 			},
 
 			getElement: function() {
@@ -1124,23 +1126,28 @@ const windowIsDefined = (typeof window === "object");
 					delete this.eventToCallbackMap[eventName];
 				}
 			},
+			_getTooltipShowClass: function() {
+				return (this.options.bsVersion === 'bs4') ? 'show' : 'in';	
+			},
 			_showTooltip: function() {
+				const showClass = this._getTooltipShowClass();
 				if (this.options.tooltip_split === false ){
-					this._addClass(this.tooltip, 'in');
+					this._addClass(this.tooltip, showClass);
 					this.tooltip_min.style.display = 'none';
 					this.tooltip_max.style.display = 'none';
 			    } else {
-					this._addClass(this.tooltip_min, 'in');
-					this._addClass(this.tooltip_max, 'in');
+					this._addClass(this.tooltip_min, showClass);
+					this._addClass(this.tooltip_max, showClass);
 					this.tooltip.style.display = 'none';
 				}
 				this._state.over = true;
 			},
 			_hideTooltip: function() {
+				const showClass = this._getTooltipShowClass();
 				if (this._state.inDrag === false && this.alwaysShowTooltip !== true) {
-					this._removeClass(this.tooltip, 'in');
-					this._removeClass(this.tooltip_min, 'in');
-					this._removeClass(this.tooltip_max, 'in');
+					this._removeClass(this.tooltip, showClass);
+					this._removeClass(this.tooltip_min, showClass);
+					this._removeClass(this.tooltip_max, showClass);
 				}
 				this._state.over = false;
 			},
@@ -1371,27 +1378,27 @@ const windowIsDefined = (typeof window === "object");
 
 					var offset_min = this.tooltip_min.getBoundingClientRect();
 					var offset_max = this.tooltip_max.getBoundingClientRect();
-
+					const positionClasses = this._getTooltipPositionClassMap();
 					if (this.options.tooltip_position === 'bottom') {
 						if (offset_min.right > offset_max.left) {
-							this._removeClass(this.tooltip_max, 'bottom');
-							this._addClass(this.tooltip_max, 'top');
+							this._removeClass(this.tooltip_max,  positionClasses.bottom);
+							this._addClass(this.tooltip_max, positionClasses.top);
 							this.tooltip_max.style.top = '';
 							this.tooltip_max.style.bottom = 22 + 'px';
 						} else {
-							this._removeClass(this.tooltip_max, 'top');
-							this._addClass(this.tooltip_max, 'bottom');
+							this._removeClass(this.tooltip_max, positionClasses.top);
+							this._addClass(this.tooltip_max, positionClasses.bottom);
 							this.tooltip_max.style.top = this.tooltip_min.style.top;
 							this.tooltip_max.style.bottom = '';
 						}
 					} else {
 						if (offset_min.right > offset_max.left) {
-							this._removeClass(this.tooltip_max, 'top');
-							this._addClass(this.tooltip_max, 'bottom');
+							this._removeClass(this.tooltip_max, positionClasses.top);
+							this._addClass(this.tooltip_max, positionClasses.bottom);
 							this.tooltip_max.style.top = 18 + 'px';
 						} else {
-							this._removeClass(this.tooltip_max, 'bottom');
-							this._addClass(this.tooltip_max, 'top');
+							this._removeClass(this.tooltip_max, positionClasses.bottom);
+							this._addClass(this.tooltip_max, positionClasses.top);
 							this.tooltip_max.style.top = this.tooltip_min.style.top;
 						}
 					}
@@ -1851,7 +1858,17 @@ const windowIsDefined = (typeof window === "object");
 			_toPercentage: function(value) {
 				return this.options.scale.toPercentage.apply(this, [value]);
 			},
+			_getTooltipPositionClassMap() {
+				const prefix = (this.options.bsVersion) === 'bs4' ? 'tooltip-' : '';
+				return {
+					right: `${prefix}right`,
+					left: `${prefix}left`,
+					top: `${prefix}top`,
+					bottom: `${prefix}bottom`,
+				};
+			},
 			_setTooltipPosition: function(){
+				const positionClasses = this._getTooltipPositionClassMap();
 				var tooltips = [this.tooltip, this.tooltip_min, this.tooltip_max];
 				if (this.options.orientation === 'vertical'){
 					var tooltipPos;
@@ -1866,17 +1883,17 @@ const windowIsDefined = (typeof window === "object");
 					}
 					var oppositeSide = (tooltipPos === 'left') ? 'right' : 'left';
 					tooltips.forEach(function(tooltip){
-						this._addClass(tooltip, tooltipPos);
+						this._addClass(tooltip, positionClasses[tooltipPos]);
 						tooltip.style[oppositeSide] = '100%';
 					}.bind(this));
 				} else if(this.options.tooltip_position === 'bottom') {
 					tooltips.forEach(function(tooltip){
-						this._addClass(tooltip, 'bottom');
+						this._addClass(tooltip, positionClasses.bottom);
 						tooltip.style.top = 22 + 'px';
 					}.bind(this));
 				} else {
 					tooltips.forEach(function(tooltip){
-						this._addClass(tooltip, 'top');
+						this._addClass(tooltip, positionClasses.top);
 						tooltip.style.top = -this.tooltip.outerHeight - 14 + 'px';
 					}.bind(this));
 				}

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1859,7 +1859,7 @@ const windowIsDefined = (typeof window === "object");
 				return this.options.scale.toPercentage.apply(this, [value]);
 			},
 			_getTooltipPositionClassMap() {
-				const prefix = (this.options.bsVersion) === 'bs4' ? 'tooltip-' : '';
+				const prefix = (this.options.bsVersion) === 'bs4' ? 'bs-tooltip-' : '';
 				return {
 					right: `${prefix}right`,
 					left: `${prefix}left`,

--- a/test/specs/BootstrapVersionSpecs.js
+++ b/test/specs/BootstrapVersionSpecs.js
@@ -1,0 +1,55 @@
+describe("'bsVersion' Option tests", function() {
+    var testSlider;
+
+    afterEach(function() {
+        if (testSlider) {
+            testSlider.destroy();
+            testSlider = null;
+        }
+    });
+
+    it('bs3 should be the default', function() {
+        testSlider = new Slider('#testSlider1', {});
+        expect(testSlider.options.bsVersion).toBe('bs3');
+    });
+
+    it('bs4 should be injectable through the constructor', function() {
+        testSlider = new Slider('#testSlider1', {
+            bsVersion: 'bs4'
+        });
+        expect(testSlider.options.bsVersion).toBe('bs4');
+    });
+
+    function testPosition(position, orientation) {
+        testSlider = new Slider('#testSlider1', {
+            bsVersion: 'bs4',
+            tooltip_position: position,
+            orientation: orientation
+        });
+        var tooltip = testSlider.tooltip;
+        var classList = tooltip.classList;
+        expect(classList).toContain('tooltip');
+        expect(classList).toContain('tooltip-' + position);
+        expect(tooltip.classList.contains(position)).toBeFalsy();
+        testSlider.destroy();
+        testSlider = null;
+    }
+
+    it('when bs4 is selected - the tooltip css changes', function() {
+        testPosition('top');
+        testPosition('bottom');
+        testPosition('left', 'vertical');
+        testPosition('right', 'vertical');
+    });
+
+    it('"show" instead of "in" triggers the visibility', function() {
+        testSlider = new Slider('#testSlider1', {
+            bsVersion: 'bs4',
+            tooltip: "always"
+        });
+        var tooltip = testSlider.tooltip;
+        var classList = tooltip.classList;
+        expect(classList).toContain('show');
+        expect(tooltip.classList.contains('in')).toBeFalsy();
+    });
+});

--- a/test/specs/BootstrapVersionSpecs.js
+++ b/test/specs/BootstrapVersionSpecs.js
@@ -29,7 +29,7 @@ describe("'bsVersion' Option tests", function() {
         var tooltip = testSlider.tooltip;
         var classList = tooltip.classList;
         expect(classList).toContain('tooltip');
-        expect(classList).toContain('tooltip-' + position);
+        expect(classList).toContain('bs-tooltip-' + position);
         expect(tooltip.classList.contains(position)).toBeFalsy();
         testSlider.destroy();
         testSlider = null;


### PR DESCRIPTION
- [x] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [x] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [x] Link to original Github issue (if this is a bug-fix)
- [x] documentation updates to README file
- [ ] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [x] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory

----

This is a first stab at Bootstrap 4 compatibilty. The idea here: Introduce a `bs_version` (`bs3` is default) (`data-slider-bs-version="bs4|bs3"`) option in order to simply support both upstream versions (3+4) in the same branch. It simply deals with new `Tooltip` css classes introduced in BS4. It is somewhat hacky :S 

The tooltips work - but they seem to need some more positioning fixes...

Fixes: https://github.com/seiyria/bootstrap-slider/issues/689
Plunkr with bs4 hard-coded as default: https://plnkr.co/edit/6fyg2tpFhNdKHQdgZ757

I have not added an example to the `tpl/index.tpl` because I am unsure how it would be best to:

* Install both versions of Boostrap as dev dependencies and have a sane build pipeline
* Deal with no "Less" files in the Bootstrap 4 package
