### PR TITLE
Fix the bug of _mouseup passing wrong value.

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1661,10 +1661,15 @@ const windowIsDefined = (typeof window === "object");
 					}
 				}
 			},
-			_mouseup: function() {
+			_mouseup: function(ev) {
 				if(!this._state.enabled) {
 					return false;
 				}
+
+				var percentage = this._getPercentage(ev);
+				this._adjustPercentageForRangeSliders(percentage);
+				this._state.percentage[this._state.dragged] = percentage;
+
 				if (this.touchCapable) {
 					// Touch: Unbind touch event handlers:
 					document.removeEventListener("touchmove", this.mousemove, false);

--- a/test/specs/DraggingHandlesSpec.js
+++ b/test/specs/DraggingHandlesSpec.js
@@ -130,7 +130,7 @@ describe("Dragging handles tests", function() {
 			expect(testSlider.getValue()).toEqual([5, 6]);
 
 			// End with mouse up
-			testSlider.mouseup();
+			testSlider.mouseup(createMouseEvent('mouseup', 6));
 			expect(testSlider._state.dragged).toBeNull();
 			expect(testSlider.getValue()).toEqual([5, 6]);
 
@@ -165,7 +165,7 @@ describe("Dragging handles tests", function() {
 			expect(testSlider.getValue()).toEqual([3, 4]);
 
 			// End with mouse up
-			testSlider.mouseup();
+			testSlider.mouseup(createMouseEvent('mouseup', 3));
 			expect(testSlider._state.dragged).toBeNull();
 			expect(testSlider.getValue()).toEqual([3, 4]);
 
@@ -206,8 +206,9 @@ describe("Dragging handles tests", function() {
         testSlider.mousemove(mouseRight);
         expect(testSlider.getValue()).toEqual([2, 5]);
 
+		// FIXME: Use 'mouseup' event type
         // End with mouse up
-        testSlider.mouseup();
+        testSlider.mouseup(mouseRight);
         expect(testSlider.getValue()).toEqual([2, 5]);
 
 	});

--- a/test/specs/DraggingHandlesSpec.js
+++ b/test/specs/DraggingHandlesSpec.js
@@ -56,6 +56,10 @@ describe("Dragging handles tests", function() {
 			var mouseRight = document.createEvent('MouseEvents');
 			mouseEventArguments[7] = tickOffsets[6]; // clientX
 			mouseRight.initMouseEvent.apply(mouseRight, mouseEventArguments);
+			// Same offset as 'mouseLeft'
+			var mouseUp = document.createEvent('MouseEvents');
+			mouseEventArguments[7] = testSlider.ticks[4].offsetLeft + testSlider.sliderElem.offsetLeft; // clientX
+			mouseUp.initMouseEvent.apply(mouseUp, mouseEventArguments);
 			// Simulate drag without swapping
 			testSlider.mousedown(mouseLeft);
 			expect(testSlider._state.dragged).toBe(0);
@@ -82,7 +86,7 @@ describe("Dragging handles tests", function() {
 			expect(testSlider._state.dragged).toBe(0);
 			expect(testSlider.getValue()).toEqual([4, 5]);
 			// End with mouse up
-			testSlider.mouseup();
+			testSlider.mouseup(mouseUp);
 			expect(testSlider._state.dragged).toBeNull();
 			expect(testSlider.getValue()).toEqual([4, 5]);
 		});

--- a/test/specs/DraggingHandlesSpec.js
+++ b/test/specs/DraggingHandlesSpec.js
@@ -212,4 +212,55 @@ describe("Dragging handles tests", function() {
         expect(testSlider.getValue()).toEqual([2, 5]);
 
 	});
+
+	describe("Test 'mousemove' and 'mouseup' produces correct results", function() {
+		var $mySlider;
+		var $handle1;
+
+		function arraysEqual(a, b) {
+			if (a === b) { return true; }
+			if (a == null || b == null) { return false; }
+			if (a.length !== b.length) { return false; }
+
+			for (var i = 0; i < a.length; ++i) {
+				if (a[i] !== b[i]) { return false; }
+			}
+			return true;
+		}
+
+		it("Last value changed in 'change' event should equal 'mouseup' event value for slider", function(done) {
+			// Change attributes for 'testSlider'
+			testSlider.setAttribute('value', 3);
+			testSlider.setAttribute('range', false);
+			testSlider.refresh();
+
+			$mySlider = $('#testSlider1');
+
+			function createMouseEvent(type, tickIdx) {
+				var mouseEvent = document.createEvent('MouseEvent');
+				mouseEventArguments[0] = type;
+				mouseEventArguments[7] = tickOffsets[tickIdx];
+				mouseEvent.initMouseEvent.apply(mouseEvent, mouseEventArguments);
+				return mouseEvent;
+			}
+
+			var lastValue = 99;  // Dummy value
+			$mySlider.on('change', function(eventData) {
+				lastValue = eventData.value.newValue;
+			});
+
+			$mySlider.on('slideStop', function(eventData) {
+				var value = eventData.value;
+				var isEqual = Array.isArray(value) ? arraysEqual(lastValue, value) : value === lastValue;
+				expect(isEqual).toBe(true);
+				done();
+			});
+
+			// Simulate drag and release from tick[1] to tick[4]
+			$handle1 = testSlider.$sliderElem.find('.slider-handle:first');
+			$handle1[0].dispatchEvent(createMouseEvent('mousedown', 1));
+			$handle1[0].dispatchEvent(createMouseEvent('mousemove', 4));
+			$handle1[0].dispatchEvent(createMouseEvent('mouseup', 4));
+		});
+	});
 });

--- a/test/specs/EventsSpec.js
+++ b/test/specs/EventsSpec.js
@@ -81,7 +81,7 @@ describe("Event Tests", function() {
           flag += 1;
         });
         testSlider.slider('refresh');
-        testSlider.data('slider')._mouseup();
+        testSlider.data('slider')._mouseup(mouse);
         expect(flag).toEqual(1);
       });
 
@@ -110,7 +110,7 @@ describe("Event Tests", function() {
           testSlider.on('slideStop', function() {
             flag = true;
           });
-          testSlider.data('slider')._mouseup();
+          testSlider.data('slider')._mouseup(mouse);
           expect(flag).not.toBeTruthy();
         });
       });
@@ -195,7 +195,7 @@ describe("Event Tests", function() {
         testSlider.on('slideStop', function() {
           flag = true;
         });
-        testSlider.data('slider')._mouseup();
+        testSlider.data('slider')._mouseup(mouse);
 
         expect(flag).toBeTruthy();
       });
@@ -209,7 +209,7 @@ describe("Event Tests", function() {
           flag += 1;
         });
         testSlider.slider('refresh');
-        testSlider.data('slider')._mouseup();
+        testSlider.data('slider')._mouseup(mouse);
 
         expect(flag).toEqual(1);
       });
@@ -260,7 +260,7 @@ describe("Event Tests", function() {
           testSlider.on('slideStop', function() {
             flag = true;
           });
-          testSlider.data('slider')._mouseup();
+          testSlider.data('slider')._mouseup(mouse);
 
           expect(flag).not.toBeTruthy();
         });

--- a/test/specs/StepReachMaxValueSpec.js
+++ b/test/specs/StepReachMaxValueSpec.js
@@ -23,7 +23,8 @@ describe("TickMaxValueNotATickBehavior", function() {
       var expectedValue = slider.options.max;
       var mouseEvent = getMouseDownEvent(offsetX, offsetY);
       slider.mousedown(mouseEvent);
-      slider.mouseup();
+      // FIXME: Use 'mouseup' event type
+      slider.mouseup(mouseEvent);
       expect(slider.getValue()).toBe(expectedValue);
     });
   });

--- a/test/specs/TickClickingBehaviorSpec.js
+++ b/test/specs/TickClickingBehaviorSpec.js
@@ -74,7 +74,8 @@ describe("TickClickingBehavior", function() {
 		var mouseEvent = getMouseDownEvent(offsetX, offsetY);
 
 		slider.mousedown(mouseEvent);
-		slider.mouseup();
+		// FIXME: Use 'mouseup' event type
+		slider.mouseup(mouseEvent);
 
 		var expectedValue = slider.options.ticks[tickIndex];
 		expect(slider.getValue()).toBe(expectedValue);

--- a/test/specs/TooltipMouseOverOptionSpec.js
+++ b/test/specs/TooltipMouseOverOptionSpec.js
@@ -43,7 +43,8 @@ describe("'ticks_tooltip' Option tests", function() {
 			//Simulate random movements
 			testSlider.mousedown(mouse49);
 			testSlider.mousemove(mouse95);
-			testSlider.mouseup();
+			// FIXME: Use 'mouseup' event type
+			testSlider.mouseup(mouse95);
 			testSlider.mousedown(mouse49);
 			testSlider.mousemove(mouse100);
 			testSlider.mousemove(mouse95);


### PR DESCRIPTION
Make _mouseup get value from event and perform the same as _mousemove and _mousedown. #824 