### PR TITLE
fixed typo in js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ To exclude JQuery from your Webpack build, you will have to go into the Webpack 
 ```js
 resolve: {
     alias: {
-         "jquery": path.join(__dirname, "./jquery-stub.js");
+         "jquery": path.join(__dirname, "./jquery-stub.js")
     }
 }
 ```


### PR DESCRIPTION
just removed a trailing ; in webpack config example