### PR TITLE
Allow any value range on logarithmic scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Options can be passed either as a data (data-slider-foo) attribute, or as part o
 | ticks_labels | array | [ ] | Defines the labels below the tick marks. Accepts HTML input. |
 | ticks_snap_bounds | float | 0 | Used to define the snap bounds of a tick. Snaps to the tick if value is within these bounds. |
 | ticks_tooltip | bool | false | Used to allow for a user to hover over a given tick to see it's value. Useful if custom formatter passed in |
-| scale | string | 'linear' | Set to 'logarithmic' to use a logarithmic scale. |
+| scale | string | 'linear' | Set to 'logarithmic' to use a logarithmic scale. Logarithmic scales will be calculated based on the difference between min to max; e.g. (0..10000) (-100..9900) both have a net range of 10001 and will slide in the same net increments. |
 | focus | bool | false | Focus the appropriate slider handle after a value change. |
 | labelledby | string,array | null | ARIA labels for the slider handle's, Use array for multiple values in a range slider. |
 | rangeHighlights | array | [] | Defines a range array that you want to highlight, for example: [{'start':val1, 'end': val2, 'class': 'optionalAdditionalClassName'}]. |

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -295,11 +295,12 @@ const windowIsDefined = (typeof window === "object");
 			logarithmic: {
 				/* Based on http://stackoverflow.com/questions/846221/logarithmic-slider */
 				toValue: function(percentage) {
-					var min = (this.options.min === 0) ? 0 : Math.log(this.options.min);
-					var max = Math.log(this.options.max);
-					var value = Math.exp(min + (max - min) * percentage / 100);
-					if(Math.round(value) === this.options.max) {
-						return this.options.max;
+					var offset = 1 - this.options.min;
+					var min = Math.log(this.options.min + offset);
+					var max = Math.log(this.options.max + offset);
+					var value = Math.exp(min + (max - min) * percentage / 100) - offset;
+					if(Math.round(value) === max) {
+						return max;
 					}
 					value = this.options.min + Math.round((value - this.options.min) / this.options.step) * this.options.step;
 					/* Rounding to the nearest step could exceed the min or
@@ -316,9 +317,10 @@ const windowIsDefined = (typeof window === "object");
 					if (this.options.max === this.options.min) {
 						return 0;
 					} else {
-						var max = Math.log(this.options.max);
-						var min = this.options.min === 0 ? 0 : Math.log(this.options.min);
-						var v = value === 0 ? 0 : Math.log(value);
+						var offset = 1 - this.options.min;
+						var max = Math.log(this.options.max + offset);
+						var min = Math.log(this.options.min + offset);
+						var v = Math.log(value + offset);
 						return 100 * (v - min) / (max - min);
 					}
 				}
@@ -1434,7 +1436,7 @@ const windowIsDefined = (typeof window === "object");
 
 				if (ev.preventDefault){
 					ev.preventDefault();
-				}				
+				}
 
 				this._state.offset = this._offset(this.sliderElem);
 				this._state.size = this.sliderElem[this.sizePos];

--- a/test/specs/LogarithmicScaleSpec.js
+++ b/test/specs/LogarithmicScaleSpec.js
@@ -11,38 +11,51 @@ describe("Slider with logarithmic scale tests", function() {
 
 	var testSlider;
 
-	it("Should properly position the slider", function() {
-		testSlider = $("#testSlider1").slider({
-			min: 0,
-			max: 10000,
-			scale: 'logarithmic',
-			value: 100 // This should be at 50%
-		});
+	describe("Should properly position the slider", function() {
 
-		var expectedPostition = 210 / 2 + 'px';
+		function testSliderPosition(min, max, value){
+			testSlider = $("#testSlider1").slider({
+    			min: min,
+    			max: max,
+    			scale: 'logarithmic',
+    			value: value // This should be at 50%
+    		});
+			var expectedPostition = 210 / 2 + 'px';
+			var handle = $("#testSlider1").siblings('div.slider').find('.min-slider-handle');
+			expect(handle.css('left')).toBe(expectedPostition);
+		}
 
-		var handle = $("#testSlider1").siblings('div.slider').find('.min-slider-handle');
-		expect(handle.css('left')).toBe(expectedPostition);
-	});
+        it("with positive values", function() {
+			testSliderPosition(1, 10000, 100);
+    	});
+
+        it("with zero", function() {
+			testSliderPosition(0, 63, 7);
+        });
+
+        it("with a negative value", function() {
+			testSliderPosition(-7, 56, 0);
+        });
+    });
 
 	it("Should properly position the tick marks", function() {
 		testSlider = $("#testSlider1").slider({
-			min: 0,
+			min: 1,
 			max: 100,
 			scale: 'logarithmic',
-			ticks: [0,10,20,50,100]
+			ticks: [1,10,20,50,100]
 		});
 
 		// Position expected for the '10' tick
 		var expectedTickOnePosition = 210 / 2 + 'px'; //should be at 50%
-		
+
 		var handle = $("#testSlider1").siblings('div.slider').find(".slider-tick").eq(1);
 		expect(handle.css('left')).toBe(expectedTickOnePosition);
 	});
 
 	it("Should use step size when navigating the keyboard", function() {
 		testSlider = $("#testSlider1").slider({
-			min: 0,
+			min: 1,
 			max: 10000,
 			scale: 'logarithmic',
 			value: 100,

--- a/test/specs/StepReachMaxValueSpec.js
+++ b/test/specs/StepReachMaxValueSpec.js
@@ -6,7 +6,7 @@ describe("TickMaxValueNotATickBehavior", function() {
   describe('max value should be reached', function() {
     beforeEach(function() {
       options = {
-        min: 39,
+        min: 40,
         max: 1310,
         step: 5,
         scale: "logarithmic",


### PR DESCRIPTION
The prior implementation required values > 0 for proper operation; by offsetting to values starting at 1, any range can be used with the logarithmic scale.

Resolves #835 

JSFiddle example: https://jsfiddle.net/j1LLdrhq/5/

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [x] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [x] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [x] Link to original Github issue (if this is a bug-fix)
- [x] documentation updates to README file
- [x] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
