### PR TITLE
Use pointer cursor on slider ticks

### DIFF
--- a/src/less/rules.less
+++ b/src/less/rules.less
@@ -219,6 +219,7 @@
 }
 .slider-tick {
 	position: absolute;
+	cursor: pointer;
 	width: @slider-line-height;
 	height: @slider-line-height;
 	#gradient.vertical(@slider-gray-6, @slider-gray-5);

--- a/src/sass/_rules.scss
+++ b/src/sass/_rules.scss
@@ -220,6 +220,7 @@
   @include slider_box-sizing(border-box);
 
   position: absolute;
+  cursor: pointer;
   width: $slider-line-height;
   height: $slider-line-height;
   filter: none;


### PR DESCRIPTION
I'm now updating from a very old version of this package, and I found that this CSS rule got removed somehow.  In my application, all the possible options are marked with ticks, and the ticks are clickable.  Yet the `cursor: pointer` rule somehow only applies everywhere *except* the tick marks (probably because of a change in how the tick marks are `position`ed).  Thus I found it necessary to make the tick marks also have the `cursor: pointer` rule.

Here's a screenshot of my use-case.  Unfortunately, I can't get the screenshot to show the cursor, but it is correct.

![image](https://user-images.githubusercontent.com/2218736/42895246-4bb7ff74-8a87-11e8-98b0-eb2f067fa6f1.png)
