### PR TITLE
629: Hovering next to slider does not show the tooltip.

### DIFF
--- a/src/less/rules.less
+++ b/src/less/rules.less
@@ -153,6 +153,7 @@
 		display: none;
 	}
 	.tooltip {
+		pointer-events: none;
 		&.top {
 			margin-top: -36px;
 		}

--- a/src/sass/_rules.scss
+++ b/src/sass/_rules.scss
@@ -140,6 +140,8 @@
     max-width: none;
   }
   .tooltip {
+    pointer-events: none;
+
     &.top {
       margin-top: -36px;
     }


### PR DESCRIPTION
refs #629

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [ ] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [ ] Link to original Github issue (if this is a bug-fix)
- [ ] documentation updates to README file
- [ ] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
