### PR TITLE
Fix Issue #854 - Range slider, min value over max value.

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1659,6 +1659,9 @@ const windowIsDefined = (typeof window === "object");
 				this._setDataVal(val);
 				this._trigger('slideStop', val);
 
+				// No longer need 'dragged' after mouse up
+				this._state.dragged = null;
+
 				return false;
 			},
 			_calculateValue: function(snapToClosestTick) {


### PR DESCRIPTION
Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [x] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [x] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [x] Link to original Github issue (if this is a bug-fix)
- [ ] documentation updates to README file
- [ ] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory

This pull request fixes https://github.com/seiyria/bootstrap-slider/issues/854. You can check the issue for my JSFiddle that is used to reproduce the bug.

I added 2 unit tests as well as making a minor edit with a unit test in the same file: `test/specs/DraggingHandlesSpec.js`.

I will say that I was getting this error `Fatal error: Callback must be a function` displayed at the very end in red text, after running the unit tests using `grunt test` command. I don't know why, thoughts?