### PR TITLE
Fix Issue #792 - Typo in the example 14 HTML

### DIFF
--- a/tpl/index.tpl
+++ b/tpl/index.tpl
@@ -660,7 +660,7 @@ var slider = new Slider("#ex13", {
       </div>
 <h5>HTML</h5>
 <pre><code class="html">
-&ltinput id="ex14" type="text" data-slider-ticks="[0, 100, 200, 300, 400]" data-slider-ticks-snap-bounds="30" data-slider-ticks-labels='["$0", "$100", "$200", "$300", "$400"]' ticks_positions="[0, 30, 60, 70, 90, 100]" /&gt
+&ltinput id="ex14" type="text" data-slider-ticks="[0, 100, 200, 300, 400]" data-slider-ticks-snap-bounds="30" data-slider-ticks-labels='["$0", "$100", "$200", "$300", "$400"]' data-slider-ticks-positions="[0, 30, 60, 70, 90, 100]" /&gt
 </code></pre>
 
 <h5>JavaScript</h5>


### PR DESCRIPTION
Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [ ] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [ ] Link to original Github issue (if this is a bug-fix)
- [ ] documentation updates to README file
- [ ] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory

Details
=============
Fixes https://github.com/seiyria/bootstrap-slider/issues/792

The input data attribute should be `data-slider-ticks-positions`.