### PR TITLE
Don't access null result from getComputedStyle

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -391,8 +391,9 @@ const windowIsDefined = (typeof window === "object");
 
 			// Check options.rtl
 			if(this.options.rtl==='auto'){
-				if (window.getComputedStyle(this.element) != null) {
-					this.options.rtl = window.getComputedStyle(this.element).direction === 'rtl';
+				var computedStyle = window.getComputedStyle(this.element);
+				if (computedStyle != null) {
+					this.options.rtl = computedStyle.direction === 'rtl';
 				} else {
 					// Fix for Firefox bug in versions less than 62:
 					// https://bugzilla.mozilla.org/show_bug.cgi?id=548397

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -391,7 +391,14 @@ const windowIsDefined = (typeof window === "object");
 
 			// Check options.rtl
 			if(this.options.rtl==='auto'){
-				this.options.rtl = window.getComputedStyle(this.element).direction==='rtl';
+				if (window.getComputedStyle(this.element) != null) {
+					this.options.rtl = window.getComputedStyle(this.element).direction === 'rtl';
+				} else {
+					// Fix for Firefox bug in versions less than 62:
+					// https://bugzilla.mozilla.org/show_bug.cgi?id=548397
+					// https://bugzilla.mozilla.org/show_bug.cgi?id=1467722
+					this.options.rtl = this.element.style.direction === 'rtl';
+				}
 			}
 
 			/*


### PR DESCRIPTION
Hello, when using this library in a front-end that was exposed via an iframe I ran into a long standing firefox bug where `getComputedStyle` would return null. https://bugzilla.mozilla.org/show_bug.cgi?id=548397

This is the workaround I implemented to work-around this issue.  Very recently, this bug has finally been [resolved ](https://bugzilla.mozilla.org/show_bug.cgi?id=1467722) in version 62, but I still figured it would be worth contributing considering the bug could still be hit on the last ~9 years of firefox releases.

Let me know if unit-tests / a JSFiddle is required for this fix and I'll see what I can do, I'm not quite sure if I could reproduce the same iframe-dependent behavior in a JSFiddle at this point.

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [ ] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [x] Link to original Github issue (if this is a bug-fix)
    - https://bugzilla.mozilla.org/show_bug.cgi?id=1467722
- [ ] ~documentation updates to README file~
- [ ] ~examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)~
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
