### PR TITLE
Fix `relayout()` making a duplicate call to `_layout()`

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1044,7 +1044,6 @@ const windowIsDefined = (typeof window === "object");
 
 			relayout: function() {
 				this._resize();
-				this._layout();
 				return this;
 			},
 


### PR DESCRIPTION
Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [ ] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [x] Link to original Github issue (if this is a bug-fix)
- [ ] documentation updates to README file
- [ ] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory

Details
=============
Fixes issue #865 

I just removed the duplicate call to `_layout()` inside the `relayout()` function because `_resize()` already makes a call to `_layout()`.