### PR TITLE
Remove extra calls that are unnecessary

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1607,7 +1607,6 @@ const windowIsDefined = (typeof window === "object");
 				var percentage = this._getPercentage(ev);
 				this._adjustPercentageForRangeSliders(percentage);
 				this._state.percentage[this._state.dragged] = percentage;
-				this._layout();
 
 				var val = this._calculateValue(true);
 				this.setValue(val, true, true);

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1577,12 +1577,10 @@ const windowIsDefined = (typeof window === "object");
 				}
 
 				this._trigger('slideStart', val);
-				this._setDataVal(val);
+
 				this.setValue(val, true, true);
 
-				this._setDataVal(val);
 				this._trigger('slideStop', val);
-				this._layout();
 
 				this._pauseEvent(ev);
 				delete this._state.keyCtrl;

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1478,7 +1478,6 @@ const windowIsDefined = (typeof window === "object");
 				}
 
 				this._state.percentage[this._state.dragged] = percentage;
-				this._layout();
 
 				if (this.touchCapable) {
 					document.removeEventListener("touchmove", this.mousemove, false);
@@ -1509,7 +1508,6 @@ const windowIsDefined = (typeof window === "object");
 
 				this._trigger('slideStart', newValue);
 
-				this._setDataVal(newValue);
 				this.setValue(newValue, false, true);
 
 				ev.returnValue = false;

--- a/test/specs/ElementDataAttributesSpec.js
+++ b/test/specs/ElementDataAttributesSpec.js
@@ -149,4 +149,63 @@ describe("Element Data Attributes Tests", function() {
   afterEach(function() {
     if(slider) { slider.slider('destroy'); }
   });
+
+  describe("Test element attribute values after calling 'setValue()'", function() {
+    var sliderObj;
+
+    afterEach(function() {
+      if (sliderObj) {
+        sliderObj.destroy();
+        sliderObj = null;
+      }
+    });
+
+    it("The 'data-value' attribute of the original <input> element should equal the new value", function() {
+      // Setup
+      var sliderInputElem = document.getElementById("testSliderGeneric");
+      var newVal = 7;
+
+      sliderObj = new Slider(sliderInputElem, {
+        min: 0,
+        max: 10,
+        value: 5
+      });
+
+      sliderObj.setValue(newVal);
+
+      expect(sliderInputElem.dataset.value).toBe(newVal.toString());
+    });
+
+    it("The 'value' attribute of the original <input> element should equal the new value", function() {
+      var sliderInputElem = document.getElementById("testSliderGeneric");
+      var newVal = 7;
+
+      sliderObj = new Slider(sliderInputElem, {
+        min: 0,
+        max: 10,
+        value: 5
+      });
+
+      sliderObj.setValue(newVal);
+
+      var sliderValueAttrib = sliderInputElem.getAttribute('value');
+
+      expect(sliderValueAttrib).toBe(newVal.toString());
+    });
+
+    it("The 'value' property of the original <input> element should equal the new value", function() {
+      var sliderInputElem = document.getElementById("testSliderGeneric");
+      var newVal = 7;
+
+      sliderObj = new Slider(sliderInputElem, {
+        min: 0,
+        max: 10,
+        value: 5
+      });
+
+      sliderObj.setValue(newVal);
+
+      expect(sliderInputElem.value).toBe(newVal.toString());
+    });
+  });
 });


### PR DESCRIPTION
I wrote unit tests for checking if `_setDataVal()` works properly.

It's going to be a bit more difficult to write tests to check if removing the calls to `_layout()` haven't broken anything.

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [ ] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
