### PR TITLE
Fix calculation of percentage values

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1569,7 +1569,7 @@ const windowIsDefined = (typeof window === "object");
 				}
 
 				var val = this._state.value[handleIdx] + dir * this.options.step;
-				const percentage = (val / this.options.max) * 100;
+				const percentage = this._toPercentage(val);
 				this._state.keyCtrl = handleIdx;
 				if (this.options.range) {
 					this._adjustPercentageForRangeSliders(percentage);
@@ -1649,12 +1649,12 @@ const windowIsDefined = (typeof window === "object");
 						this._state.percentage[1] = this._state.percentage[0];
 						this._state.dragged = 0;
 					}
-					else if (this._state.keyCtrl === 0 && (((this._state.value[1] / this.options.max) * 100) < percentage)) {
+					else if (this._state.keyCtrl === 0 && (this._toPercentage(this._state.value[1]) < percentage)) {
 						this._state.percentage[0] = this._state.percentage[1];
 						this._state.keyCtrl = 1;
 						this.handle2.focus();
 					}
-					else if (this._state.keyCtrl === 1 && (((this._state.value[0] / this.options.max) * 100) > percentage)) {
+					else if (this._state.keyCtrl === 1 && (this._toPercentage(this._state.value[0]) > percentage)) {
 						this._state.percentage[1] = this._state.percentage[0];
 						this._state.keyCtrl = 0;
 						this.handle1.focus();

--- a/test/specs/KeyboardSupportSpec.js
+++ b/test/specs/KeyboardSupportSpec.js
@@ -340,6 +340,7 @@ describe("Keyboard Support Tests", function() {
     describe("when handle1 tries to overtake handle2 from the left", function() {
       beforeEach(function() {
         handle1 = $("#testSlider").find(".slider-handle:first");
+        handle2 = $("#testSlider").find(".slider-handle:last");
         handle1.focus();
       });
 
@@ -368,10 +369,21 @@ describe("Keyboard Support Tests", function() {
         keyboardEvent.keyCode = keyboardEvent.which = 39;
         handle1[0].dispatchEvent(keyboardEvent);
       });
+
+      it("Should give focus to handle2 after overtaking from the left", function(done) {
+        handle2.on("focus", function() {
+          expect(true).toBe(true);
+          done();
+        });
+
+        keyboardEvent.keyCode = keyboardEvent.which = 39;
+        handle1[0].dispatchEvent(keyboardEvent);
+      });
     });
 
     describe("when handle2 tries to overtake handle1 from the right", function() {
       beforeEach(function() {
+        handle1 = $("#testSlider").find(".slider-handle:first");
         handle2 = $("#testSlider").find(".slider-handle:last");
         handle2.focus();
       });
@@ -395,6 +407,16 @@ describe("Keyboard Support Tests", function() {
 
         handle2.on("keydown", function() {
           expect(sliderValue[1]).toBe(initialSliderVal);
+          done();
+        });
+
+        keyboardEvent.keyCode = keyboardEvent.which = 37;
+        handle2[0].dispatchEvent(keyboardEvent);
+      });
+
+      it("Should give focus to handle1 after overtaking from the right", function(done) {
+        handle1.on("focus", function() {
+          expect(true).toBe(true);
           done();
         });
 


### PR DESCRIPTION
The percentage values were being miscalculated.

Old equation was taking into account negative min values.

Wrong
`(val / this.options.max) * 100;`

Correct
`((val - this.options.min) / (this.options.max - this.options.min)) * 100;`

```
min, max = -100, 100
val = 10
// old
percentage
= (10 / 100) * 100
= 10%

// fix
percentage
= [ (10 - (-100)) / (100 - (-100) ] * 100
= [ (10 + 100) / (100 + 100) ] * 100
= 110 / 200 * 100
= 55%
```

So I just make call to `this._toPercentage()`.