### PR TITLE
Add '_copyState()' function

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1167,11 +1167,25 @@ const windowIsDefined = (typeof window === "object");
 					return [state.percentage[0], state.percentage[1]];
 				}
 			},
+			_copyState: function() {
+				return {
+					value: [ this._state.value[0], this._state.value[1] ],
+					enabled: this._state.enabled,
+					offset: this._state.offset,
+					size: this._state.size,
+					percentage: [ this._state.percentage[0], this._state.percentage[1], this._state.percentage[2] ],
+					inDrag: this._state.inDrag,
+					over: this._state.over,
+					// deleted or null'd keys
+					dragged: this._state.dragged,
+					keyCtrl: this._state.keyCtrl
+				};
+			},
 			_addTickListener: function _addTickListener() {
 				return {
 					addMouseEnter: function(reference, tick, index){
 						var enter = function(){
-							var tempState = reference._state;
+							var tempState = reference._copyState();
 							var idString = index >= 0 ? index : this.attributes['aria-valuenow'].value;
 							var hoverIndex = parseInt(idString, 10);
 							tempState.value[0] = hoverIndex;


### PR DESCRIPTION
Fixes #882 

Since the `_state` is relatively small, I just simply copied over the keys and values. But I'm not sure where to put the `_copyState()` function though. Any suggestions?

I will add a unit test as well.

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [ ] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [x] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [x] Link to original Github issue (if this is a bug-fix)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
