### PR TITLE
Fix #887 doesn't destory the silder instance cause "generates mutiple silder instance" test failed

### DIFF
--- a/test/specs/PublicMethodsSpec.js
+++ b/test/specs/PublicMethodsSpec.js
@@ -19,6 +19,7 @@ describe("Public Method Tests", function() {
       expect(sliderInstancesExists).toBeTruthy();
       var sliderInstancesCount = $(".makeSlider").siblings(".slider").length;
       expect(sliderInstancesCount).toEqual(2);
+
       $('.makeSlider').slider('destroy');
     });
 

--- a/test/specs/PublicMethodsSpec.js
+++ b/test/specs/PublicMethodsSpec.js
@@ -14,14 +14,12 @@ describe("Public Method Tests", function() {
     });
 
     it("generates multiple slider instances from selector", function() {
-
       $(".makeSlider").slider();
-
       var sliderInstancesExists = $(".makeSlider").siblings().is(".slider");
       expect(sliderInstancesExists).toBeTruthy();
-
       var sliderInstancesCount = $(".makeSlider").siblings(".slider").length;
       expect(sliderInstancesCount).toEqual(2);
+      $('.makeSlider').slider('destroy');
     });
 
     it("reads and sets the 'min' option properly", function() {
@@ -146,21 +144,20 @@ describe("Public Method Tests", function() {
       expect(sliderSelectionHeightAtMaxValue).toBe(0);
     });
 
-    /* TODO: Fix this test! It keeps throwing a weird bug where is says '955' instead of '9' for the value */
-    // it("reads and sets the 'formatter' option properly", function() {
-    //   var tooltipFormatter = function(value) {
-    //     return 'Current value: ' + value;
-    //   };
+    it("reads and sets the 'formatter' option properly", function() {
+      var tooltipFormatter = function(value) {
+        return 'Current value: ' + value;
+      };
 
-    //   testSlider = $("#testSlider1").slider({
-    //     formatter : tooltipFormatter
-    //   });
-    //   testSlider.slider('setValue', 9);
+      testSlider = $("#testSlider1").slider({
+        formatter : tooltipFormatter
+      });
+      testSlider.slider('setValue', 9);
 
-    //   var tooltipMessage = $("#testSlider1").siblings(".slider").find("div.tooltip").children("div.tooltip-inner").text();
-    //   var expectedMessage = tooltipFormatter(9);
-    //   expect(tooltipMessage).toBe(expectedMessage);
-    // });
+      var tooltipMessage = $("#testSlider1").siblings(".slider").find("div.tooltip").children("div.tooltip-inner").text();
+      var expectedMessage = tooltipFormatter(9);
+      expect(tooltipMessage).toBe(expectedMessage);
+    });
 
     it("reads and sets the 'enabled' option properly", function() {
       testSlider = $("#testSlider1").slider({


### PR DESCRIPTION
Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [ ] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [ ] Link to original Github issue (if this is a bug-fix)
- [ ] documentation updates to README file
- [ ] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
