### PR TITLE
Fixes Issue #690 ticks should not overwrite min/max settings

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -372,6 +372,9 @@ const windowIsDefined = (typeof window === "object");
 			options = options ? options : {};
 			var optionTypes = Object.keys(this.defaultOptions);
 
+			const isMinSet = options.hasOwnProperty('min');
+			const isMaxSet = options.hasOwnProperty('max');
+
 			for(var i = 0; i < optionTypes.length; i++) {
 				var optName = optionTypes[i];
 
@@ -692,8 +695,12 @@ const windowIsDefined = (typeof window === "object");
 			this._setTooltipPosition();
 			/* In case ticks are specified, overwrite the min and max bounds */
 			if (Array.isArray(this.options.ticks) && this.options.ticks.length > 0) {
+				if (!isMaxSet) {
 					this.options.max = Math.max.apply(Math, this.options.ticks);
+				}
+				if (!isMinSet) {
 					this.options.min = Math.min.apply(Math, this.options.ticks);
+				}
 			}
 
 			if (Array.isArray(this.options.value)) {

--- a/test/specs/TickMarksSpec.js
+++ b/test/specs/TickMarksSpec.js
@@ -59,17 +59,6 @@ describe("Slider with ticks tests", function() {
 		});
 	});
 
-	it("Should overwrite the min/max values", function() {
-		testSlider = $("#testSlider1").slider({
-			ticks: [100, 200, 300, 400, 500],
-			min: 15000,
-			max: 25000
-		});
-
-		expect(testSlider.slider('getAttribute','min')).toBe(100);
-		expect(testSlider.slider('getAttribute','max')).toBe(500);
-	});
-
 	it("Should not snap to a tick within tick bounds when using the keyboard navigation", function() {
 		testSlider = $("#testSlider1").slider({
 			ticks: [100, 200, 300, 400, 500],
@@ -190,5 +179,69 @@ describe("Slider with ticks tests", function() {
       testSlider.slider('destroy');
       testSlider = null;
     }
+	});
+});
+
+describe("Slider min/max settings", function() {
+	var $inputSlider;
+
+	afterEach(function() {
+		if ($inputSlider) {
+			if ($inputSlider instanceof jQuery) {
+				$inputSlider.slider('destroy');
+			}
+			$inputSlider = null;
+		}
+	});
+
+	it("Should use min/max tick values for min/max settings", function() {
+		$inputSlider = $('#testSlider1').slider({
+			ticks: [1, 2, 3]
+		});
+
+		expect($inputSlider.slider('getAttribute', 'min')).toBe(1);
+		expect($inputSlider.slider('getAttribute', 'max')).toBe(3);
+	});
+
+	it("Should not overwrite 'min' setting", function() {
+		$inputSlider = $('#testSlider1').slider({
+			min: 0,
+			ticks: [1, 2, 3]
+		});
+
+		expect($inputSlider.slider('getAttribute', 'min')).toBe(0);
+		expect($inputSlider.slider('getAttribute', 'max')).toBe(3);
+	});
+
+	it("Should not overwrite 'max' setting", function() {
+		$inputSlider = $('#testSlider1').slider({
+			max: 5,
+			ticks: [1, 2, 3]
+		});
+
+		expect($inputSlider.slider('getAttribute', 'min')).toBe(1);
+		expect($inputSlider.slider('getAttribute', 'max')).toBe(5);
+	});
+
+	it("Should not overwrite 'min' or max' settings", function() {
+		$inputSlider = $('#testSlider1').slider({
+			min: 0,
+			max: 5,
+			ticks: [1, 2, 3]
+		});
+
+		expect($inputSlider.slider('getAttribute', 'min')).toBe(0);
+		expect($inputSlider.slider('getAttribute', 'max')).toBe(5);
+	});
+
+	it("Should ignore the ticks when outside of min/max range", function() {
+		$inputSlider = $("#testSlider1").slider({
+			ticks: [100, 200, 300, 400, 500],
+			min: 15000,
+			max: 25000
+		});
+
+		expect($inputSlider.slider('getAttribute', 'min')).toBe(15000);
+		expect($inputSlider.slider('getAttribute', 'max')).toBe(25000);
 	});
 });


### PR DESCRIPTION
Fixes #690 

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [x] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [x] Link to original Github issue (if this is a bug-fix)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
