### PR TITLE
Fixes Issue #884: Hovering over ticks displays the tick index

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1213,10 +1213,10 @@ const windowIsDefined = (typeof window === "object");
 				return {
 					addMouseEnter: function(reference, element, index){
 						var enter = function(){
-							var tempState = reference._copyState();
+							let tempState = reference._copyState();
 							// Which handle is being hovered over?
-							var val = element === reference.handle1 ? tempState.value[0] : tempState.value[1];
-							var per;
+							let val = element === reference.handle1 ? tempState.value[0] : tempState.value[1];
+							let per;
 
 							// Setup value and percentage for tick's 'mouseenter'
 							if (index !== undefined) {

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1211,11 +1211,11 @@ const windowIsDefined = (typeof window === "object");
 			},
 			_addTickListener: function _addTickListener() {
 				return {
-					addMouseEnter: function(reference, tick, index){
+					addMouseEnter: function(reference, element, index){
 						var enter = function(){
 							var tempState = reference._copyState();
 							// Which handle is being hovered over?
-							var val = tick === reference.handle1 ? tempState.value[0] : tempState.value[1];
+							var val = element === reference.handle1 ? tempState.value[0] : tempState.value[1];
 							var per;
 
 							// Setup value and percentage for tick's 'mouseenter'
@@ -1233,14 +1233,14 @@ const windowIsDefined = (typeof window === "object");
 							reference._setToolTipOnMouseOver(tempState);
 							reference._showTooltip();
 						};
-						tick.addEventListener("mouseenter", enter, false);
+						element.addEventListener("mouseenter", enter, false);
 						return enter;
 					},
-					addMouseLeave: function(reference, tick){
+					addMouseLeave: function(reference, element){
 						var leave = function(){
 							reference._hideTooltip();
 						};
-						tick.addEventListener("mouseleave", leave, false);
+						element.addEventListener("mouseleave", leave, false);
 						return leave;
 					}
 				};

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1214,10 +1214,22 @@ const windowIsDefined = (typeof window === "object");
 					addMouseEnter: function(reference, tick, index){
 						var enter = function(){
 							var tempState = reference._copyState();
-							var idString = index >= 0 ? index : this.attributes['aria-valuenow'].value;
-							var hoverIndex = parseInt(idString, 10);
-							tempState.value[0] = hoverIndex;
-							tempState.percentage[0] = reference.options.ticks_positions[hoverIndex];
+							// Which handle is being hovered over?
+							var val = tick === reference.handle1 ? tempState.value[0] : tempState.value[1];
+							var per;
+
+							// Setup value and percentage for tick's 'mouseenter'
+							if (index !== undefined) {
+								val = reference.options.ticks[index];
+								per = (reference.options.ticks_positions.length > 0 && reference.options.ticks_positions[index]) ||
+									reference._toPercentage(reference.options.ticks[index]);
+							}
+							else {
+								per = reference._toPercentage(val);
+							}
+
+							tempState.value[0] = val;
+							tempState.percentage[0] = per;
 							reference._setToolTipOnMouseOver(tempState);
 							reference._showTooltip();
 						};

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1182,6 +1182,7 @@ const windowIsDefined = (typeof window === "object");
 				this._state.over = false;
 			},
 			_setToolTipOnMouseOver: function _setToolTipOnMouseOver(tempState){
+				let self = this;
 				var formattedTooltipVal = this.options.formatter(!tempState ? this._state.value[0]: tempState.value[0]);
 				var positionPercentages = !tempState ? getPositionPercentages(this._state, this.options.reversed) : getPositionPercentages(tempState, this.options.reversed);
 				this._setText(this.tooltipInner, formattedTooltipVal);
@@ -1190,7 +1191,7 @@ const windowIsDefined = (typeof window === "object");
 
 				function getPositionPercentages(state, reversed){
 					if (reversed) {
-						return [100 - state.percentage[0], this.options.range ? 100 - state.percentage[1] : state.percentage[1]];
+						return [100 - state.percentage[0], self.options.range ? 100 - state.percentage[1] : state.percentage[1]];
 					}
 					return [state.percentage[0], state.percentage[1]];
 				}

--- a/test/specs/TooltipMouseOverOptionSpec.js
+++ b/test/specs/TooltipMouseOverOptionSpec.js
@@ -1,5 +1,28 @@
 describe("'ticks_tooltip' Option tests", function() {
 	var testSlider;
+	var mouseEventArguments;
+
+	beforeEach(function() {
+		// Set up default set of mouse event arguments
+		mouseEventArguments = [
+			'mousemove', // type
+			true, // canBubble
+			true, // cancelable
+			document, // view,
+			0, // detail
+			0, // screenX
+			0, // screenY
+			undefined, // clientX
+			undefined, // clientY,
+			false, // ctrlKey
+			false, // altKey
+			false, // shiftKey
+			false, // metaKey,
+			0, // button
+			null // relatedTarget
+		];
+	});
+
 	describe("ticks_tooltip states", function() {
         it("should have the tooltip above the last hovered over element", function() {
             testSlider = new Slider(document.getElementById("testSlider1"), {
@@ -10,23 +33,7 @@ describe("'ticks_tooltip' Option tests", function() {
                 ticks_tooltip: true,
                 orientation: 'horizontal'
 			});
-			var mouseEventArguments = [
-				'mousemove', // type
-				true, // canBubble
-				true, // cancelable
-				document, // view,
-				0, // detail
-				0, // screenX
-				0, // screenY
-				undefined, // clientX
-				testSlider.sliderElem.offsetTop, // clientY,
-				false, // ctrlKey
-				false, // altKey
-				false, // shiftKey
-				false, // metaKey,
-				0, // button
-				null // relatedTarget
-			];
+			mouseEventArguments[8] = testSlider.sliderElem.offsetTop; // clientY
 			var mouse49 = document.createEvent('MouseEvents');
 			mouseEventArguments[7] = testSlider.ticks[4].offsetLeft + testSlider.sliderElem.offsetLeft; // clientX
 			mouse49.initMouseEvent.apply(mouse49, mouseEventArguments);
@@ -67,23 +74,7 @@ describe("'ticks_tooltip' Option tests", function() {
 				ticks_tooltip: true,
 				orientation: 'horizontal'
 			});
-			var mouseEventArguments = [
-				'mousemove', // type
-				true, // canBubble
-				true, // cancelable
-				document, // view,
-				0, // detail
-				0, // screenX
-				0, // screenY
-				undefined, // clientX
-				testSlider.sliderElem.offsetTop, // clientY,
-				false, // ctrlKey
-				false, // altKey
-				false, // shiftKey
-				false, // metaKey,
-				0, // button
-				null // relatedTarget
-			];
+			var bigOffset = 100000;
 
 			var isTooltipVisible = $('#mySlider').find('.tooltip.tooltip-main').hasClass('in');
 			expect(isTooltipVisible).toBe(true);
@@ -96,8 +87,7 @@ describe("'ticks_tooltip' Option tests", function() {
 
 			var mouseleave = document.createEvent('MouseEvent');
 			mouseEventArguments[0] = 'mouseleave';
-			mouseEventArguments[7] = testSlider.sliderElem.offsetLeft + testSlider.sliderElem.offsetWidth;
-				// testSlider.ticks[1].offsetLeft + testSlider.sliderElem.offsetLeft; // clientX
+			mouseEventArguments[7] = testSlider.sliderElem.offsetLeft + bigOffset;
 			mouseleave.initMouseEvent.apply(mouseleave, mouseEventArguments);
 
 			testSlider.ticks[1].addEventListener('mouseleave', function() {
@@ -116,5 +106,340 @@ describe("'ticks_tooltip' Option tests", function() {
 			if(testSlider instanceof Slider) { testSlider.destroy(); }
 			testSlider = null;
 		}
+	});
+});
+
+/**
+ * The mouse navigation tests are based on the following slider properties:
+ *
+ * initial value: 3 or [3, 7]
+ * ticks: [0, 3, 5, 7, 10]
+ * step: 1
+ *
+ * When the `ticks_tooltip` option is set to `true`, hovering over the ticks or handles
+ * should show the tooltip above it with the value of the tick/handle.
+ *
+ * The test logic for sliders:
+ * 1. Hover over the 1st tick
+ * 2. Check if the tooltip is positioned correctly (left, top, right)
+ * 3. Check if the tooltip should be showing
+ * 4. Check if the tooltip contains the correct value
+ * 5. Check if the slider value(s) haven't changed
+ *
+ */
+describe("`ticks_tooltip: true` mouse navigation test cases", function() {
+	var initialValue = 3;
+	var initialRangeValues = [3, 7];
+	var tickValues = [0, 3, 5, 7, 10];
+	var stepValue = 1;
+
+	var orientations = ['horizontal', 'vertical'];
+	var reversed = [false, true];
+	var sliderTypes = ['single', 'range'];
+	var rtl = [false, true];
+	var testCases = [];
+	var mouseEventArguments;
+
+	function calcMouseEventCoords(element) {
+		var elementBB = element.getBoundingClientRect();
+
+		return {
+			clientX: elementBB.left,
+			clientY: elementBB.top
+		};
+	}
+
+	function createMouseEvent(type, clientX, clientY) {
+		var mouseEvent = document.createEvent('MouseEvent');
+		mouseEventArguments[0] = type;
+		mouseEventArguments[7] = clientX;
+		mouseEventArguments[8] = clientY;
+		mouseEvent.initMouseEvent.apply(mouseEvent, mouseEventArguments);
+		return mouseEvent;
+	}
+
+	beforeEach(function() {
+		// Set up default set of mouse event arguments
+		mouseEventArguments = [
+			'mousemove', // type
+			true, // canBubble
+			true, // cancelable
+			document, // view,
+			0, // detail
+			0, // screenX
+			0, // screenY
+			undefined, // clientX
+			undefined, // clientY,
+			false, // ctrlKey
+			false, // altKey
+			false, // shiftKey
+			false, // metaKey,
+			0, // button
+			null // relatedTarget
+		];
+	});
+
+	sliderTypes.forEach(function(sliderType) {
+		orientations.forEach(function(orientation) {
+			rtl.forEach(function(isRTL) {
+				reversed.forEach(function(isReversed) {
+					var isHorizontal = orientation === 'horizontal';
+					var isVertical = orientation === 'vertical';
+					var isRange = sliderType === 'range';
+					var whichStyle;
+
+					if (isHorizontal) {
+						if (isRTL) {
+							whichStyle = 'right';
+						}
+						else {
+							whichStyle = 'left';
+						}
+					}
+					else if (isVertical) {
+						whichStyle = 'top';
+					}
+
+					testCases.push({
+						value: isRange ? initialRangeValues : initialValue,
+						step: stepValue,
+						range: isRange,
+						orientation: orientation,
+						reversed: isReversed,
+						rtl: 'auto',
+						isRTL: isRTL,
+						inputId: isRTL ? 'rtlSlider' : 'testSlider1',
+						expectedValue: isRange ? initialRangeValues : initialValue,
+						stylePos: whichStyle
+					});
+				});
+			});
+		});
+	});
+
+	testCases.forEach(function(testCase) {
+		describe("range=" + testCase.range + ", orientation=" + testCase.orientation +
+			", rtl=" + testCase.isRTL + ", reversed=" + testCase.reversed, function() {
+			var $testSlider;
+			var sliderElem;
+			var $handle1;
+			var $handle2;
+			var $ticks;
+			var sliderId;
+			var sliderOptions;
+			var $tooltip;
+			var $tooltipInner;
+			var lastTickIndex;
+			var mouseEventType = 'mouseenter';
+
+			beforeEach(function() {
+				sliderId = testCase.range ? 'myRangeSlider' : 'mySlider';
+
+				sliderOptions = {
+					id: sliderId,
+					step: testCase.step,
+					orientation: testCase.orientation,
+					value: testCase.value,
+					range: testCase.range,
+					reversed: testCase.reversed,
+					rtl: 'auto',
+					ticks: tickValues,
+					ticks_tooltip: true
+				};
+
+				$testSlider = $('#'+testCase.inputId).slider(sliderOptions);
+				sliderElem = $('#'+sliderId)[0];
+				$ticks = $(sliderElem).find('.slider-tick');
+				$handle1 = $(sliderElem).find('.slider-handle:first');
+				$handle2 = $(sliderElem).find('.slider-handle:last');
+				$tooltip = $(sliderElem).find('.tooltip.tooltip-main');
+				$tooltipInner = $tooltip.find('.tooltip-inner');
+				lastTickIndex = sliderOptions.ticks.length - 1;
+			});
+
+			afterEach(function() {
+				// Clean up any associated event listeners
+				$ticks = null;
+				$handle1 = null;
+				$handle2 = null;
+
+				if ($testSlider) {
+					$testSlider.slider('destroy');
+					$testSlider = null;
+				}
+			});
+
+			it("Should position the tooltip correctly", function(done) {
+				$ticks.each(function(index, tickElem) {
+					var coords = calcMouseEventCoords(tickElem);
+
+					var tickCallback = function() {
+						// Check position
+						expect($tooltip.css(testCase.stylePos)).toBe($(this).css(testCase.stylePos));
+
+						if (index === lastTickIndex) {
+							done();
+						}
+					};
+
+					// Set up listener and dispatch event
+					this.addEventListener(mouseEventType, tickCallback, false);
+					this.dispatchEvent(createMouseEvent(mouseEventType, coords.clientX, coords.clientY));
+				});
+			});
+
+			it("Should show the tooltip", function(done) {
+				$ticks.each(function(index, tickElem) {
+					var coords = calcMouseEventCoords(tickElem);
+
+					var tickCallback = function() {
+						// Check that tooltip shows
+						expect($tooltip.hasClass('in')).toBe(true);
+
+						if (index === lastTickIndex) {
+							done();
+						}
+					};
+
+					this.addEventListener(mouseEventType, tickCallback, false);
+					this.dispatchEvent(createMouseEvent(mouseEventType, coords.clientX, coords.clientY));
+				});
+			});
+
+			it("Should not show the tooltip", function(done) {
+				var bigOffset = 100000;
+
+				$ticks.each(function(index, tickElem) {
+					var coords = calcMouseEventCoords(tickElem);
+
+					var tickCallback = function() {
+						// Check that tooltip shows
+						expect($tooltip.hasClass('in')).toBe(false);
+
+						if (index === lastTickIndex) {
+							done();
+						}
+					};
+
+					this.addEventListener('mouseleave', tickCallback, false);
+					this.dispatchEvent(createMouseEvent('mouseleave', coords.clientX + bigOffset, coords.clientY));
+				});
+			});
+
+			it("Should contain the correct value for the tooltip", function(done) {
+				$ticks.each(function(index, tickElem) {
+					var coords = calcMouseEventCoords(tickElem);
+
+					var tickCallback = function() {
+						// Check value of tooltip
+						expect($tooltipInner.text()).toBe(''+sliderOptions.ticks[index]);
+
+						if (index === lastTickIndex) {
+							done();
+						}
+					};
+
+					this.addEventListener(mouseEventType, tickCallback, false);
+					this.dispatchEvent(createMouseEvent(mouseEventType, coords.clientX, coords.clientY));
+				});
+			});
+
+			it("Should not modify the value(s) of the slider when displaying the tooltip", function(done) {
+				$ticks.each(function(index, tickElem) {
+					var coords = calcMouseEventCoords(tickElem);
+
+					var tickCallback = function() {
+						var value = $testSlider.slider('getValue');
+
+						// Check value of slider
+						expect(value).toEqual(testCase.expectedValue);
+
+						if (index === lastTickIndex) {
+							done();
+						}
+					};
+
+					this.addEventListener(mouseEventType, tickCallback, false);
+					this.dispatchEvent(createMouseEvent(mouseEventType, coords.clientX, coords.clientY));
+				});
+			});
+
+			describe("Test position and values of the tooltip when hovering over the handle(s)", function() {
+
+				if (testCase.range) {
+					it("Should position for the tooltip correctly (range)", function(done) {
+						var handleElems = [$handle1[0], $handle2[0]];
+
+						$.each(handleElems, function(index, handleElem) {
+							var coords = calcMouseEventCoords(handleElem, testCase.orientation);
+
+							var handleCallback = function() {
+								// Check position
+								expect($tooltip.css(testCase.stylePos)).toBe($(handleElem).css(testCase.stylePos));
+
+								if (index === 1) {
+									done();
+								}
+							};
+
+							handleElem.addEventListener(mouseEventType, handleCallback, false);
+							handleElem.dispatchEvent(createMouseEvent(mouseEventType, coords.clientX, coords.clientY));
+						});
+					});
+
+					it("Should contain the correct values for the tooltip (range)", function(done) {
+						var handleElems = [$handle1[0], $handle2[0]];
+
+						$.each(handleElems, function(index, handleElem) {
+							var coords = calcMouseEventCoords(handleElem, testCase.orientation);
+
+							var handleCallback = function() {
+								// Check value of tooltip
+								expect($tooltipInner.text()).toBe(''+testCase.expectedValue[index]);
+
+								if (index === 1) {
+									done();
+								}
+							};
+
+							handleElem.addEventListener(mouseEventType, handleCallback, false);
+							handleElem.dispatchEvent(createMouseEvent(mouseEventType, coords.clientX, coords.clientY));
+						});
+					});
+
+				}
+				else {
+					it("Should position for the tooltip correctly (single)", function(done) {
+						var handleElem = $handle1[0];
+
+						var coords = calcMouseEventCoords(handleElem, testCase.orientation);
+
+						var handleCallback = function() {
+							// Check position
+							expect($tooltip.css(testCase.stylePos)).toBe($(handleElem).css(testCase.stylePos));
+							done();
+						};
+
+						handleElem.addEventListener(mouseEventType, handleCallback, false);
+						handleElem.dispatchEvent(createMouseEvent(mouseEventType, coords.clientX, coords.clientY));
+					});
+
+					it("Should contain the correct value for the tooltip (single)", function(done) {
+						var handleElem = $handle1[0];
+
+						var coords = calcMouseEventCoords(handleElem, testCase.orientation);
+
+						var handleCallback = function() {
+							// Check value of tooltip
+							expect($tooltipInner.text()).toBe(''+testCase.expectedValue);
+							done();
+						};
+
+						handleElem.addEventListener(mouseEventType, handleCallback, false);
+						handleElem.dispatchEvent(createMouseEvent(mouseEventType, coords.clientX, coords.clientY));
+					});
+				}
+			});
+		});
 	});
 });


### PR DESCRIPTION
Fixes #884 

This displays the correct value for the tick and correctly positions the tooltip above the tick.

Will add unit tests.

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [x] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [x] Link to original Github issue (if this is a bug-fix)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
