### PR TITLE
Remove unnecessary call to parseFloat()

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1751,7 +1751,6 @@ const windowIsDefined = (typeof window === "object");
 					}	
 				} else {
 					val = this._toValue(this._state.percentage[0]);
-					val = parseFloat(val);
 					val = this._applyPrecision(val);
 					if (snapToClosestTick) {
 						val = this._snapToClosestTick(val);


### PR DESCRIPTION
Fixes #875 

https://github.com/seiyria/bootstrap-slider/blob/88dfe2aa20bb49f524b681062e6ea15d26402c41/src/js/bootstrap-slider.js#L258-L267

This line should convert the value to a float/double if the `step` is also a float/double.

https://github.com/seiyria/bootstrap-slider/blob/88dfe2aa20bb49f524b681062e6ea15d26402c41/src/js/bootstrap-slider.js#L259

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [ ] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [x] Link to original Github issue (if this is a bug-fix)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
