### PR TITLE
Fix namespace handling

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -225,6 +225,7 @@ const windowIsDefined = (typeof window === "object");
 	**************************************************/
 
 	(function($) {
+		let autoRegisterNamespace;
 
 		var ErrorMsgs = {
 			formatInvalidInputErrorMsg : function(input) {
@@ -992,7 +993,10 @@ const windowIsDefined = (typeof window === "object");
 				// Remove JQuery handlers/data
 				if($) {
 					this._unbindJQueryEventHandlers();
-					this.$element.removeData('slider');
+					if (autoRegisterNamespace === NAMESPACE_MAIN) {
+						this.$element.removeData(autoRegisterNamespace);
+					}
+					this.$element.removeData(NAMESPACE_ALTERNATE);
 				}
 			},
 
@@ -1061,7 +1065,13 @@ const windowIsDefined = (typeof window === "object");
 				createNewSlider.call(this, this.element, this.options);
 				if($) {
 					// Bind new instance of slider to the element
-					$.data(this.element, 'slider', this);
+					if (autoRegisterNamespace === NAMESPACE_MAIN) {
+						$.data(this.element, NAMESPACE_MAIN, this);
+						$.data(this.element, NAMESPACE_ALTERNATE, this);
+					}
+					else {
+						$.data(this.element, NAMESPACE_ALTERNATE, this);
+					}
 				}
 				return this;
 			},
@@ -1974,8 +1984,6 @@ const windowIsDefined = (typeof window === "object");
 
 		*********************************/
 		if($ && $.fn) {
-			let autoRegisterNamespace;
-
 			if (!$.fn.slider) {
 				$.bridget(NAMESPACE_MAIN, Slider);
 				autoRegisterNamespace = NAMESPACE_MAIN;

--- a/test/specs/AriaValueTextFormatterSpec.js
+++ b/test/specs/AriaValueTextFormatterSpec.js
@@ -15,7 +15,8 @@ describe("Aria-valuetext Tests", function() {
       var tooltipMessageA = $("#accessibilitySliderA").prev(".slider").children(".min-slider-handle").attr("aria-valuetext");
       var expectedMessageA = tooltipFormatterA(2);
       expect(tooltipMessageA).toBe(expectedMessageA);
-     
+
+      $("#accessibilitySliderA").slider('destroy');
     });
     
     it("Does not use aria-valuetext if 'formatter' is not used", function() {
@@ -26,6 +27,8 @@ describe("Aria-valuetext Tests", function() {
     
       var ariaValueTextB = $("#accessibilitySliderB").prev(".slider").children(".min-slider-handle").attr("aria-valuetext");
       expect(ariaValueTextB).not.toBeDefined();
+
+      $("#accessibilitySliderB").slider('destroy');
     });
     
     it("aria-valuetext if 'formatter' is used and has min & max value", function() {

--- a/test/specs/DestroyMethodTests.js
+++ b/test/specs/DestroyMethodTests.js
@@ -20,6 +20,50 @@ describe("'destroy()' Method tests", function() {
     expect(sliderChildrenElements).toBe(0);
   });
 
+  describe("Destroy slider instance associated with <input> element", function() {
+    var sourceJS = "temp/bootstrap-slider.js";
+    var defaultNamespace = 'slider';
+    var alternateNamespace = 'bootstrapSlider';
+
+    it("Should remove the instance associated with the <input> DOM element", function() {
+      var $testSlider = $('#testSlider1').slider();
+
+      var sliderInst = $testSlider.data(defaultNamespace);
+      expect(sliderInst).toBeTruthy();
+
+      $testSlider.slider('destroy');
+      sliderInst = $testSlider.data(defaultNamespace);
+      expect(sliderInst).toBeUndefined();
+    });
+
+    describe("Check alternate namespace", function() {
+
+      afterEach(function(done) {
+        $.fn.bootstrapSlider = undefined;
+        $.fn.slider = undefined;
+    
+        $.getScript(sourceJS, function() {
+          done();
+        });
+      });
+
+      it("Should remove the instance associated with the <input> DOM element with alternate namespace", function(done) {
+        $.fn.slider = function() {};
+
+        $.getScript(sourceJS, function() {
+          var $testSlider = $('#testSlider1').bootstrapSlider();
+
+          $testSlider.bootstrapSlider('destroy');
+
+          var sliderInst = $testSlider.data(alternateNamespace);
+          expect(sliderInst).toBeUndefined();
+
+          done();
+        });
+      });
+    });
+  });
+
   describe("unbinds all slider events", function() {
     var flag, evtName;
 

--- a/test/specs/DestroyMethodTests.js
+++ b/test/specs/DestroyMethodTests.js
@@ -142,6 +142,8 @@ describe("'destroy()' Method tests", function() {
         throwsRuntimeError = true;
       }
 
+      testSlider.destroy();
+
       // reCreateSliderAndBindEvent(): Assert error is not thrown
       expect(throwsRuntimeError).toBeFalsy();
     });

--- a/test/specs/EventsSpec.js
+++ b/test/specs/EventsSpec.js
@@ -214,17 +214,17 @@ describe("Event Tests", function() {
         expect(flag).toEqual(1);
       });
 
-      it("slider should not bind multiple touchstart events after calling 'refresh'", function() {
+      it("slider should not bind multiple touchstart events after calling 'refresh'", function(done) {
         touch.initEvent("touchstart", true, true);
         flag = 0;
 
         testSlider.on('slideStart', function() {
           flag += 1;
+          expect(flag).toEqual(1);
+          done();
         });
         testSlider.slider('refresh');
         $('.slider .slider-handle').get(0).dispatchEvent(touch);
-
-        expect(flag).toEqual(1);
       });
 
       describe("Disabled Slider Event Tests", function() {

--- a/test/specs/EventsSpec.js
+++ b/test/specs/EventsSpec.js
@@ -224,7 +224,7 @@ describe("Event Tests", function() {
           done();
         });
         testSlider.slider('refresh');
-        $('.slider .slider-handle').get(0).dispatchEvent(touch);
+        $('#testSlider2').prev('div.slider').find('.slider-handle').get(0).dispatchEvent(touch);
       });
 
       describe("Disabled Slider Event Tests", function() {

--- a/test/specs/LogarithmicScaleSpec.js
+++ b/test/specs/LogarithmicScaleSpec.js
@@ -21,7 +21,7 @@ describe("Slider with logarithmic scale tests", function() {
     			value: value // This should be at 50%
     		});
 			var expectedPostition = 210 / 2 + 'px';
-			var handle = $("#testSlider1").siblings('div.slider').find('.min-slider-handle');
+			var handle = $("#testSlider1").prev('div.slider').find('.min-slider-handle');
 			expect(handle.css('left')).toBe(expectedPostition);
 		}
 
@@ -49,7 +49,7 @@ describe("Slider with logarithmic scale tests", function() {
 		// Position expected for the '10' tick
 		var expectedTickOnePosition = 210 / 2 + 'px'; //should be at 50%
 
-		var handle = $("#testSlider1").siblings('div.slider').find(".slider-tick").eq(1);
+		var handle = $("#testSlider1").prev('div.slider').find(".slider-tick").eq(1);
 		expect(handle.css('left')).toBe(expectedTickOnePosition);
 	});
 
@@ -63,7 +63,7 @@ describe("Slider with logarithmic scale tests", function() {
 		});
 
 		// Focus on handle1
-		var handle1 = $("#testSlider1").siblings('div.slider:first').find('.slider-handle');
+		var handle1 = $("#testSlider1").prev('div.slider').find('.slider-handle');
 		handle1.focus();
 
 		// Create keyboard event

--- a/test/specs/NamespaceSpec.js
+++ b/test/specs/NamespaceSpec.js
@@ -1,5 +1,7 @@
 describe("Namespace Tests", function() {
   var sourceJS = "temp/bootstrap-slider.js";
+  var defaultNamespace = 'slider';
+  var alternateNamespace = 'bootstrapSlider';
 
   it("should always set the plugin namespace to 'bootstrapSlider'", function(done) {
     $.getScript(sourceJS, function() {
@@ -22,6 +24,36 @@ describe("Namespace Tests", function() {
     $.getScript(sourceJS, function() {
       var expectedWarningMessage = "bootstrap-slider.js - WARNING: $.fn.slider namespace is already bound. Use the $.fn.bootstrapSlider namespace instead.";
       expect(window.console.warn).toHaveBeenCalledWith(expectedWarningMessage);
+      done();
+    });
+  });
+
+  it("Should not create instance when 'slider' namespace is in use", function(done) {
+    $.fn.slider = function() {};  // Overwrite temporarily
+
+    $.getScript(sourceJS, function() {
+      var $testSlider = $('#testSlider1').bootstrapSlider();
+
+      var sliderInst = $testSlider.data(defaultNamespace);
+      expect(sliderInst).toBeUndefined();
+
+      $testSlider.bootstrapSlider('destroy');
+
+      done();
+    });
+  });
+
+  it("Should create instance associated with the alternate 'bootstrapSlider' namespace", function(done) {
+    $.fn.slider = function() {};
+
+    $.getScript(sourceJS, function() {
+      var $testSlider = $('#testSlider1').bootstrapSlider();
+
+      var sliderInst = $testSlider.data(alternateNamespace);
+      expect(sliderInst).toBeTruthy();
+
+      $testSlider.bootstrapSlider('destroy');
+
       done();
     });
   });

--- a/test/specs/TickMarksSpec.js
+++ b/test/specs/TickMarksSpec.js
@@ -66,7 +66,7 @@ describe("Slider with ticks tests", function() {
 		});
 
 		// Focus on handle1
-		var handle1 = $("#testSlider1").siblings('div.slider:first').find('.slider-handle');
+		var handle1 = $("#testSlider1").prev('div.slider').find('.slider-handle');
 		handle1.focus();
 
 		// Create keyboard event


### PR DESCRIPTION
I noticed these two lines were incorrect. The slider instance that is added/removed should be based on the namespace, either: _slider_ or _bootstrapSlider_.

https://github.com/seiyria/bootstrap-slider/blob/88dfe2aa20bb49f524b681062e6ea15d26402c41/src/js/bootstrap-slider.js#L995

https://github.com/seiyria/bootstrap-slider/blob/88dfe2aa20bb49f524b681062e6ea15d26402c41/src/js/bootstrap-slider.js#L1064

I added unit tests.

I also fixed some unit tests that were not properly destroying the `<div>` slider element. This caused some unit tests to fail when it used `.siblings()` to check the `<div>` slider element, but the method also collects more than 1 `<div>` if they exist, which was causing hard to track bugs.

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [x] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
