### PR TITLE
Fix tooltip when option is set to 'always'

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1162,7 +1162,7 @@ const windowIsDefined = (typeof window === "object");
 				this._state.over = true;
 			},
 			_hideTooltip: function() {
-				if (this._state.inDrag === false && this.alwaysShowTooltip !== true) {
+				if (this._state.inDrag === false && this._alwaysShowTooltip !== true) {
 					this._removeClass(this.tooltip, 'in');
 					this._removeClass(this.tooltip_min, 'in');
 					this._removeClass(this.tooltip_max, 'in');

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1093,10 +1093,12 @@ const windowIsDefined = (typeof window === "object");
 						ticks[i].removeEventListener('mouseenter', this.ticksCallbackMap[i].mouseEnter, false);
 						ticks[i].removeEventListener('mouseleave', this.ticksCallbackMap[i].mouseLeave, false);
 					}
-					this.handle1.removeEventListener('mouseenter', this.handleCallbackMap.handle1.mouseEnter, false);
-					this.handle2.removeEventListener('mouseenter', this.handleCallbackMap.handle2.mouseEnter, false);
-					this.handle1.removeEventListener('mouseleave', this.handleCallbackMap.handle1.mouseLeave, false);
-					this.handle2.removeEventListener('mouseleave', this.handleCallbackMap.handle2.mouseLeave, false);
+					if (this.handleCallbackMap.handle1 && this.handleCallbackMap.handle2) {
+						this.handle1.removeEventListener('mouseenter', this.handleCallbackMap.handle1.mouseEnter, false);
+						this.handle2.removeEventListener('mouseenter', this.handleCallbackMap.handle2.mouseEnter, false);
+						this.handle1.removeEventListener('mouseleave', this.handleCallbackMap.handle1.mouseLeave, false);
+						this.handle2.removeEventListener('mouseleave', this.handleCallbackMap.handle2.mouseLeave, false);
+					}
 				}
 
 				this.handleCallbackMap = null;

--- a/test/specs/TooltipMouseOverOptionSpec.js
+++ b/test/specs/TooltipMouseOverOptionSpec.js
@@ -53,6 +53,64 @@ describe("'ticks_tooltip' Option tests", function() {
             expect(testSlider.tooltip.style.left).toBe("0%");
 		});
 	});
+
+	describe("Always show the tooltip", function() {
+		it("Should always display the tooltip after hovering over a tick", function(done) {
+			testSlider = new Slider(document.getElementById("testSlider1"), {
+				id: 'mySlider',
+				min: 0,
+				max: 10,
+				step: 1,
+				value: 1,
+				ticks: [0, 5, 10],
+				tooltip: 'always',
+				ticks_tooltip: true,
+				orientation: 'horizontal'
+			});
+			var mouseEventArguments = [
+				'mousemove', // type
+				true, // canBubble
+				true, // cancelable
+				document, // view,
+				0, // detail
+				0, // screenX
+				0, // screenY
+				undefined, // clientX
+				testSlider.sliderElem.offsetTop, // clientY,
+				false, // ctrlKey
+				false, // altKey
+				false, // shiftKey
+				false, // metaKey,
+				0, // button
+				null // relatedTarget
+			];
+
+			var isTooltipVisible = $('#mySlider').find('.tooltip.tooltip-main').hasClass('in');
+			expect(isTooltipVisible).toBe(true);
+
+			var mouseenter = document.createEvent('MouseEvent');
+			mouseEventArguments[0] = 'mouseenter';
+			mouseEventArguments[7] = 
+				testSlider.ticks[1].offsetLeft + testSlider.sliderElem.offsetLeft; // clientX
+			mouseenter.initMouseEvent.apply(mouseenter, mouseEventArguments);
+
+			var mouseleave = document.createEvent('MouseEvent');
+			mouseEventArguments[0] = 'mouseleave';
+			mouseEventArguments[7] = testSlider.sliderElem.offsetLeft + testSlider.sliderElem.offsetWidth;
+				// testSlider.ticks[1].offsetLeft + testSlider.sliderElem.offsetLeft; // clientX
+			mouseleave.initMouseEvent.apply(mouseleave, mouseEventArguments);
+
+			testSlider.ticks[1].addEventListener('mouseleave', function() {
+				isTooltipVisible = $('#mySlider').find('.tooltip.tooltip-main').hasClass('in');
+				expect(isTooltipVisible).toBe(true);
+				done();
+			});
+
+			testSlider.ticks[1].dispatchEvent(mouseenter);
+			testSlider.ticks[1].dispatchEvent(mouseleave);
+		});
+	});
+
 	afterEach(function() {
 		if(testSlider) {
 			if(testSlider instanceof Slider) { testSlider.destroy(); }


### PR DESCRIPTION
Fix typo with variable name. Just added `_` underscore.

Changed `this.alwaysShowTooltip` to `this._alwaysShowTooltip`

https://github.com/seiyria/bootstrap-slider/blob/88dfe2aa20bb49f524b681062e6ea15d26402c41/src/js/bootstrap-slider.js#L809-L812

https://github.com/seiyria/bootstrap-slider/blob/88dfe2aa20bb49f524b681062e6ea15d26402c41/src/js/bootstrap-slider.js#L1164-L1171

Added a unit test.

Also there was a bug when `options.tooltip` was set to `'always'` and the `options.ticks_tooltip` was set to `true`.

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [x] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [ ] Link to original Github issue (if this is a bug-fix)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
