### PR TITLE
Fix touch drag on mobile devices

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -782,8 +782,10 @@ const windowIsDefined = (typeof window === "object");
 			this.touchstart = this._touchstart.bind(this);
 			this.touchmove = this._touchmove.bind(this);
 
-			this.sliderElem.addEventListener("touchstart", this.touchstart, false);
-			this.sliderElem.addEventListener("touchmove", this.touchmove, false);
+			if (this.touchCapable) {
+				this.sliderElem.addEventListener("touchstart", this.touchstart, false);
+				this.sliderElem.addEventListener("touchmove", this.touchmove, false);
+			}
 
 			this.sliderElem.addEventListener("mousedown", this.mousedown, false);
 
@@ -826,24 +828,29 @@ const windowIsDefined = (typeof window === "object");
 					this.sliderElem.addEventListener("mouseenter", this.showTooltip, false);
 					this.sliderElem.addEventListener("mouseleave", this.hideTooltip, false);
 
-					this.sliderElem.addEventListener("touchstart", this.showTooltip, false);
-					this.sliderElem.addEventListener("touchmove", this.showTooltip, false);
-					this.sliderElem.addEventListener("touchend", this.hideTooltip, false);
+					if (this.touchCapable) {
+						this.sliderElem.addEventListener("touchstart", this.showTooltip, false);
+						this.sliderElem.addEventListener("touchmove", this.showTooltip, false);
+						this.sliderElem.addEventListener("touchend", this.hideTooltip, false);
+					}
 				}
 
 				this.handle1.addEventListener("focus", this.showTooltip, false);
 				this.handle1.addEventListener("blur", this.hideTooltip, false);
 
-				this.handle1.addEventListener("touchstart", this.showTooltip, false);
-				this.handle1.addEventListener("touchmove", this.showTooltip, false);
-				this.handle1.addEventListener("touchend", this.hideTooltip, false);
-
+				
 				this.handle2.addEventListener("focus", this.showTooltip, false);
 				this.handle2.addEventListener("blur", this.hideTooltip, false);
 
-				this.handle2.addEventListener("touchstart", this.showTooltip, false);
-				this.handle2.addEventListener("touchmove", this.showTooltip, false);
-				this.handle2.addEventListener("touchend", this.hideTooltip, false);
+				if (this.touchCapable) {
+					this.handle1.addEventListener("touchstart", this.showTooltip, false);
+					this.handle1.addEventListener("touchmove", this.showTooltip, false);
+					this.handle1.addEventListener("touchend", this.hideTooltip, false);
+
+					this.handle2.addEventListener("touchstart", this.showTooltip, false);
+					this.handle2.addEventListener("touchmove", this.showTooltip, false);
+					this.handle2.addEventListener("touchend", this.hideTooltip, false);
+				}
 			}
 
 			if(this.options.enabled) {
@@ -1143,31 +1150,47 @@ const windowIsDefined = (typeof window === "object");
 				if (this.showTooltip) {
 					this.handle1.removeEventListener("focus", this.showTooltip, false);
 					this.handle2.removeEventListener("focus", this.showTooltip, false);
-					this.handle1.removeEventListener("touchstart", this.showTooltip, false);
-					this.handle1.removeEventListener("touchmove", this.showTooltip, false);
-					this.handle2.removeEventListener("touchstart", this.showTooltip, false);
-					this.handle2.removeEventListener("touchmove", this.showTooltip, false);
 				}
 				if (this.hideTooltip) {
 					this.handle1.removeEventListener("blur", this.hideTooltip, false);
 					this.handle2.removeEventListener("blur", this.hideTooltip, false);
-					this.handle1.removeEventListener("touchend", this.hideTooltip, false);
-					this.handle2.removeEventListener("touchend", this.hideTooltip, false);
 				}
 
 				// Remove event listeners from sliderElem
 				if (this.showTooltip) {
 					this.sliderElem.removeEventListener("mouseenter", this.showTooltip, false);
-					this.sliderElem.removeEventListener("touchstart", this.showTooltip, false);
-					this.sliderElem.removeEventListener("touchmove", this.showTooltip, false);
 				}
 				if (this.hideTooltip) {
 					this.sliderElem.removeEventListener("mouseleave", this.hideTooltip, false);
-					this.sliderElem.removeEventListener("touchend", this.hideTooltip, false);
 				}
-				this.sliderElem.removeEventListener("touchstart", this.touchstart, false);
-				this.sliderElem.removeEventListener("touchmove", this.touchmove, false);
+
 				this.sliderElem.removeEventListener("mousedown", this.mousedown, false);
+
+				if (this.touchCapable) {
+					// Remove touch event listeners from handles
+					if (this.showTooltip) {
+						this.handle1.removeEventListener("touchstart", this.showTooltip, false);
+						this.handle1.removeEventListener("touchmove", this.showTooltip, false);
+						this.handle2.removeEventListener("touchstart", this.showTooltip, false);
+						this.handle2.removeEventListener("touchmove", this.showTooltip, false);
+					}
+					if (this.hideTooltip) {
+						this.handle1.removeEventListener("touchend", this.hideTooltip, false);
+						this.handle2.removeEventListener("touchend", this.hideTooltip, false);
+					}
+
+					// Remove event listeners from sliderElem
+					if (this.showTooltip) {
+						this.sliderElem.removeEventListener("touchstart", this.showTooltip, false);
+						this.sliderElem.removeEventListener("touchmove", this.showTooltip, false);
+					}
+					if (this.hideTooltip) {
+						this.sliderElem.removeEventListener("touchend", this.hideTooltip, false);
+					}
+
+					this.sliderElem.removeEventListener("touchstart", this.touchstart, false);
+					this.sliderElem.removeEventListener("touchmove", this.touchmove, false);
+				}
 
 				// Remove window event listener
 				window.removeEventListener("resize", this.resize, false);

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1120,9 +1120,9 @@ const windowIsDefined = (typeof window === "object");
 				_fnName : function() {...}
 
 			********************************/
-			_removeTooltipListener: function(event) {
-				this.handle1.removeEventListener(event, this.showTooltip, false);
-				this.handle2.removeEventListener(event, this.showTooltip, false);
+			_removeTooltipListener: function(event, handler) {
+				this.handle1.removeEventListener(event, handler, false);
+				this.handle2.removeEventListener(event, handler, false);
 			},
 			_removeSliderEventHandlers: function() {
 				// Remove keydown event listeners
@@ -1148,12 +1148,10 @@ const windowIsDefined = (typeof window === "object");
 				this.ticksCallbackMap = null;
 
 				if (this.showTooltip) {
-					this.handle1.removeEventListener("focus", this.showTooltip, false);
-					this.handle2.removeEventListener("focus", this.showTooltip, false);
+					this._removeTooltipListener("focus", this.showTooltip);
 				}
 				if (this.hideTooltip) {
-					this.handle1.removeEventListener("blur", this.hideTooltip, false);
-					this.handle2.removeEventListener("blur", this.hideTooltip, false);
+					this._removeTooltipListener("blur", this.hideTooltip);
 				}
 
 				// Remove event listeners from sliderElem

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -782,23 +782,9 @@ const windowIsDefined = (typeof window === "object");
 			this.touchstart = this._touchstart.bind(this);
 			this.touchmove = this._touchmove.bind(this);
 
-			if (this.touchCapable) {
-				// Test for passive event support
-				let supportsPassive = false;
-				try {
-					let opts = Object.defineProperty({}, 'passive', {
-						get: function() {
-							supportsPassive = true;
-						}
-					});
-					window.addEventListener("test", null, opts);
-				} catch (e) {}
-				// Use our detect's results. passive applied if supported, capture will be false either way.
-				let eventOptions = supportsPassive ? { passive: true } : false;
-				// Bind touch handlers
-				this.sliderElem.addEventListener("touchstart", this.touchstart, eventOptions);
-				this.sliderElem.addEventListener("touchmove", this.touchmove, eventOptions);
-			}
+			this.sliderElem.addEventListener("touchstart", this.touchstart, false);
+			this.sliderElem.addEventListener("touchmove", this.touchmove, false);
+
 			this.sliderElem.addEventListener("mousedown", this.mousedown, false);
 
 			// Bind window handlers
@@ -1609,14 +1595,7 @@ const windowIsDefined = (typeof window === "object");
 				return true;
 			},
 			_touchstart: function(ev) {
-				if (ev.changedTouches === undefined) {
-					this._mousedown(ev);
-					return;
-				}
-
-				var touch = ev.changedTouches[0];
-				this.touchX = touch.pageX;
-				this.touchY = touch.pageY;
+				this._mousedown(ev);
 			},
 			_triggerFocusOnHandle: function(handleIdx) {
 				if(handleIdx === 0) {
@@ -1743,20 +1722,9 @@ const windowIsDefined = (typeof window === "object");
 					return;
 				}
 
-				var touch = ev.changedTouches[0];
-
-				var xDiff = touch.pageX - this.touchX;
-				var yDiff = touch.pageY - this.touchY;
-
-				if (!this._state.inDrag) {
-					// Vertical Slider
-					if (this.options.orientation === 'vertical' && (xDiff <= 5 && xDiff >= -5) && (yDiff >=15 || yDiff <= -15)) {
-						this._mousedown(ev);
-					}
-					// Horizontal slider.
-					else if ((yDiff <= 5 && yDiff >= -5) && (xDiff >= 15 || xDiff <= -15)) {
-						this._mousedown(ev);
-					}
+				// Prevent page from scrolling and only drag the slider
+				if(ev.preventDefault) {
+					ev.preventDefault();
 				}
 			},
 			_adjustPercentageForRangeSliders: function(percentage) {
@@ -1874,7 +1842,7 @@ const windowIsDefined = (typeof window === "object");
 				Source: http://stackoverflow.com/questions/10454518/javascript-how-to-retrieve-the-number-of-decimals-of-a-string-number
 			*/
 			_getPercentage: function(ev) {
-				if (this.touchCapable && (ev.type === 'touchstart' || ev.type === 'touchmove')) {
+				if (this.touchCapable && (ev.type === 'touchstart' || ev.type === 'touchmove' || ev.type === 'touchend')) {
 					ev = ev.touches[0];
 				}
 

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -825,13 +825,25 @@ const windowIsDefined = (typeof window === "object");
 				} else {
 					this.sliderElem.addEventListener("mouseenter", this.showTooltip, false);
 					this.sliderElem.addEventListener("mouseleave", this.hideTooltip, false);
+
+					this.sliderElem.addEventListener("touchstart", this.showTooltip, false);
+					this.sliderElem.addEventListener("touchmove", this.showTooltip, false);
+					this.sliderElem.addEventListener("touchend", this.hideTooltip, false);
 				}
 
 				this.handle1.addEventListener("focus", this.showTooltip, false);
 				this.handle1.addEventListener("blur", this.hideTooltip, false);
 
+				this.handle1.addEventListener("touchstart", this.showTooltip, false);
+				this.handle1.addEventListener("touchmove", this.showTooltip, false);
+				this.handle1.addEventListener("touchend", this.hideTooltip, false);
+
 				this.handle2.addEventListener("focus", this.showTooltip, false);
 				this.handle2.addEventListener("blur", this.hideTooltip, false);
+
+				this.handle2.addEventListener("touchstart", this.showTooltip, false);
+				this.handle2.addEventListener("touchmove", this.showTooltip, false);
+				this.handle2.addEventListener("touchend", this.hideTooltip, false);
 			}
 
 			if(this.options.enabled) {
@@ -1129,18 +1141,29 @@ const windowIsDefined = (typeof window === "object");
 				this.ticksCallbackMap = null;
 
 				if (this.showTooltip) {
-					this._removeTooltipListener("focus");
+					this.handle1.removeEventListener("focus", this.showTooltip, false);
+					this.handle2.removeEventListener("focus", this.showTooltip, false);
+					this.handle1.removeEventListener("touchstart", this.showTooltip, false);
+					this.handle1.removeEventListener("touchmove", this.showTooltip, false);
+					this.handle2.removeEventListener("touchstart", this.showTooltip, false);
+					this.handle2.removeEventListener("touchmove", this.showTooltip, false);
 				}
 				if (this.hideTooltip) {
-					this._removeTooltipListener("blur");
+					this.handle1.removeEventListener("blur", this.hideTooltip, false);
+					this.handle2.removeEventListener("blur", this.hideTooltip, false);
+					this.handle1.removeEventListener("touchend", this.hideTooltip, false);
+					this.handle2.removeEventListener("touchend", this.hideTooltip, false);
 				}
 
 				// Remove event listeners from sliderElem
 				if (this.showTooltip) {
 					this.sliderElem.removeEventListener("mouseenter", this.showTooltip, false);
+					this.sliderElem.removeEventListener("touchstart", this.showTooltip, false);
+					this.sliderElem.removeEventListener("touchmove", this.showTooltip, false);
 				}
 				if (this.hideTooltip) {
 					this.sliderElem.removeEventListener("mouseleave", this.hideTooltip, false);
+					this.sliderElem.removeEventListener("touchend", this.hideTooltip, false);
 				}
 				this.sliderElem.removeEventListener("touchstart", this.touchstart, false);
 				this.sliderElem.removeEventListener("touchmove", this.touchmove, false);

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1866,7 +1866,7 @@ const windowIsDefined = (typeof window === "object");
 			*/
 			_getPercentage: function(ev) {
 				if (this.touchCapable && (ev.type === 'touchstart' || ev.type === 'touchmove' || ev.type === 'touchend')) {
-					ev = ev.touches[0];
+					ev = ev.changedTouches[0];
 				}
 
 				var eventPosition = ev[this.mousePos];

--- a/test/specs/EventsSpec.js
+++ b/test/specs/EventsSpec.js
@@ -1,5 +1,6 @@
 describe("Event Tests", function() {
   var testSlider, flag, mouse;
+  var sliderElem;
 
   beforeEach(function() {
     flag = false;
@@ -11,6 +12,7 @@ describe("Event Tests", function() {
       testSlider = $("#testSlider2").slider({
         value: 1
       });
+      sliderElem = testSlider.slider('getElement');
     });
 
     afterEach(function() {
@@ -18,6 +20,7 @@ describe("Event Tests", function() {
         testSlider.slider('destroy');
         testSlider = null;
       }
+      sliderElem = null;
     });
 
     describe("Mouse Events", function() {
@@ -137,11 +140,15 @@ describe("Event Tests", function() {
     describe("Touch Events", function() {
       var touch;
       var spy;
+      var coords;
+      var touchStart;
+      var touchMove;
+      var touchEnd;
 
       /*
-            list can be either [[x, y], [x, y]] or [x, y]
-        */
-       function createTouchList(target, list) {
+          list can be either [[x, y], [x, y]] or [x, y]
+      */
+      function createTouchList(target, list) {
         if (Array.isArray(list) && list[0] && !Array.isArray(list[0])) {
             list = [list];
         }
@@ -206,6 +213,11 @@ describe("Event Tests", function() {
         touch.touches = [dummyTouchEvent];
         window.ontouchstart = true;
         spy = jasmine.createSpy('spy');
+
+        coords = calcTouchEventCoords(sliderElem);
+        touchStart = createTouchEvent(sliderElem, 'touchstart', [coords.clientX, coords.clientY]);
+        touchMove = createTouchEvent(sliderElem, 'touchmove', [coords.clientX, coords.clientY]);
+        touchEnd = createTouchEvent(sliderElem, 'touchend', [[0, 0]]);
       });
 
       afterEach(function() {
@@ -213,10 +225,6 @@ describe("Event Tests", function() {
       });
 
       it("'slideStart' event is triggered properly and can be binded to", function(done) {
-        var sliderElem = testSlider.slider('getElement');
-
-        var coords = calcTouchEventCoords(sliderElem);
-        var touchEvent = createTouchEvent(sliderElem, 'touchstart', [coords.clientX, coords.clientY]);
         testSlider.on('slideStart', spy);
 
         window.setTimeout(function() {
@@ -224,27 +232,36 @@ describe("Event Tests", function() {
           done();
         });
 
-        sliderElem.dispatchEvent(touchEvent);
+        sliderElem.dispatchEvent(touchStart);
+        sliderElem.dispatchEvent(touchEnd);
       });
 
       it("'slide' event is triggered properly and can be binded to", function(done) {
-        touch.initEvent("touchmove");
         testSlider.on('slide', spy);
-        testSlider.data('slider')._mousemove(touch);
+
         window.setTimeout(function() {
           expect(spy).toHaveBeenCalled();
           done();
         });
+
+        // Expect to fail if ONLY dispatching 'touchmove' because `preventDefault()` will prevent
+        // the browser from sending the corresponding 'mousemove'.
+        // The 'mousedown' event must happen first via 'touchstart'.
+        sliderElem.dispatchEvent(touchStart);
+        sliderElem.dispatchEvent(touchMove);
+        // Always call 'touchend' to remove any touch event listeners on the document.
+        sliderElem.dispatchEvent(touchEnd);
       });
 
       it("'slide' event sets the right value on the input", function(done) {
-        touch.initEvent("touchmove");
-
         testSlider.on('slide', function() {
           expect(isNaN(testSlider.val())).not.toBeTruthy();
           done();
         });
-        testSlider.data('slider')._mousemove(touch);
+
+        sliderElem.dispatchEvent(touchStart);
+        sliderElem.dispatchEvent(touchMove);
+        sliderElem.dispatchEvent(touchEnd);
       });
 
       it("'slide' event value and input value properties are synchronous", function() {
@@ -262,32 +279,38 @@ describe("Event Tests", function() {
       });
 
       it("'slideStop' event is triggered properly and can be binded to", function(done) {
-        touch.initEvent("touchstop");
         testSlider.on('slideStop', spy);
-        testSlider.data('slider')._mouseup(mouse);
+
         window.setTimeout(function() {
           expect(spy).toHaveBeenCalled();
           done();
         });
+
+        sliderElem.dispatchEvent(touchStart);
+        sliderElem.dispatchEvent(touchMove);
+        sliderElem.dispatchEvent(touchEnd);
       });
 
-
       it("slider should not have duplicate events after calling 'refresh'", function(done) {
-        touch.initEvent("touchstop");
+        // FIXME: Should set `flag` to 0 and make sure spy is called only once
         testSlider.on('slideStop', spy);
-        testSlider.slider('refresh');
-        testSlider.data('slider')._mouseup(mouse);
+
         window.setTimeout(function() {
           expect(spy).toHaveBeenCalled();
           done();
         });
+
+        sliderElem.dispatchEvent(touchStart);
+        sliderElem.dispatchEvent(touchMove);
+        sliderElem.dispatchEvent(touchEnd);
+        testSlider.slider('refresh');
       });
 
       it("slider should not bind multiple touchstart events after calling 'refresh'", function(done) {
         flag = 0;
         var obj = {
             addOne: function() {
-            flag++;
+                flag++;
             }
         };
         spyOn(obj, 'addOne').and.callThrough();
@@ -296,8 +319,11 @@ describe("Event Tests", function() {
 
         testSlider.on('slideStart', obj.addOne);
 
+        var handleElem = $('#testSlider2').prev('div.slider').find('.slider-handle:first').get(0);
+        handleElem.dispatchEvent(touchStart);
+        handleElem.dispatchEvent(touchMove);
+        handleElem.dispatchEvent(touchEnd);
         testSlider.slider('refresh');
-        $('#testSlider2').prev('div.slider').find('.slider-handle').get(0).dispatchEvent(touch);
 
         window.setTimeout(function() {
             expect(flag).toBe(1);

--- a/test/specs/TouchCapableSpec.js
+++ b/test/specs/TouchCapableSpec.js
@@ -182,6 +182,69 @@ describe("Touch Capable Tests", function() {
 
   });
 
+  describe("single, vertical slider", function() {
+
+    beforeEach(function() {
+      // Initialize the slider
+      sliderOptions.orientation = 'vertical';
+      $testSlider = $('#' + inputId).slider(sliderOptions);
+
+      // Get slider instance
+      sliderInst = $testSlider.data('slider');
+    });
+
+    // index= [0 1 2 3 4]
+    // ticks= [0 3 5 7 10]
+    it("should slide the handle to the top from 5 to 3", function(done) {
+      var sliderElem = $testSlider.slider('getElement');
+      $testSlider.on('slideStop', function() {
+        var value = $testSlider.slider('getValue');
+        expect(value).toBe(3);
+        done();
+      });
+
+      var tick = sliderInst.ticks[2];  // 5
+      var sliderCoords = calcTouchEventCoords(sliderElem);
+      var coords = [sliderCoords.x, sliderCoords.y + tick.offsetTop];
+      touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
+
+      tick = sliderInst.ticks[1];  // 3
+      coords = [sliderCoords.x, sliderCoords.y + tick.offsetTop];
+      touchMove = createTouchEvent(sliderElem, 'touchmove', coords);
+
+      touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+
+      sliderElem.dispatchEvent(touchStart);
+      sliderElem.dispatchEvent(touchMove);
+      sliderElem.dispatchEvent(touchEnd);
+    });
+
+    it("should slide the handle to the bottom from 5 to 7", function(done) {
+      var sliderElem = $testSlider.slider('getElement');
+      $testSlider.on('slideStop', function() {
+        var value = $testSlider.slider('getValue');
+        expect(value).toBe(7);
+        done();
+      });
+
+      var tick = sliderInst.ticks[2];  // 5
+      var sliderCoords = calcTouchEventCoords(sliderElem);
+      var coords = [sliderCoords.x, sliderCoords.y + tick.offsetTop];
+      touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
+
+      tick = sliderInst.ticks[3];  // 7
+      coords = [sliderCoords.x, sliderCoords.y + tick.offsetTop];
+      touchMove = createTouchEvent(sliderElem, 'touchmove', coords);
+
+      touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+
+      sliderElem.dispatchEvent(touchStart);
+      sliderElem.dispatchEvent(touchMove);
+      sliderElem.dispatchEvent(touchEnd);
+    });
+
+  });
+
   describe("range slider", function() {
 
     beforeEach(function() {

--- a/test/specs/TouchCapableSpec.js
+++ b/test/specs/TouchCapableSpec.js
@@ -480,4 +480,92 @@ describe("Touch Capable Tests", function() {
 
   });
 
+  describe("Scrolling tests", function() {
+
+    describe("horizontal sliding tests", function() {
+      var horzScrollDiv;
+
+      beforeEach(function() {
+        // Initialize the slider
+        $testSlider = $('#' + inputId).slider(sliderOptions);
+
+        // Get slider instance
+        sliderInst = $testSlider.data('slider');
+
+        horzScrollDiv = document.getElementById('horz-scroll-div');
+      });
+
+      // index= [0 1 2 3 4]
+      // ticks= [0 3 5 7 10]
+      it("should not scroll the div horizontally while sliding the slider", function(done) {
+        var sliderElem = $testSlider.slider('getElement');
+
+        $testSlider.on('slideStop', function() {
+          expect(horzScrollDiv.scrollLeft).toBe(0);
+          done();
+        });
+
+        var tick = sliderInst.ticks[2];  // 5
+        var sliderCoords = calcTouchEventCoords(sliderElem);
+        var coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+        touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
+
+        tick = sliderInst.ticks[3];  // 7
+        coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+        touchMove = createTouchEvent(sliderElem, 'touchmove', coords);
+
+        touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+
+        sliderElem.dispatchEvent(touchStart);
+        sliderElem.dispatchEvent(touchMove);
+        sliderElem.dispatchEvent(touchEnd);
+      });
+
+    });
+
+    describe("vertical sliding tests", function() {
+      var vertScrollDiv;
+
+      beforeEach(function() {
+        sliderOptions.orientation = 'vertical';
+
+        // Initialize the slider
+        $testSlider = $('#' + inputId).slider(sliderOptions);
+
+        // Get slider instance
+        sliderInst = $testSlider.data('slider');
+
+        vertScrollDiv = document.getElementById('vert-scroll-div');
+      });
+
+      // index= [0 1 2 3 4]
+      // ticks= [0 3 5 7 10]
+      it("should not scroll the div vertically while sliding the slider", function(done) {
+        var sliderElem = $testSlider.slider('getElement');
+
+        $testSlider.on('slideStop', function() {
+          expect(vertScrollDiv.scrollTop).toBe(0);
+          done();
+        });
+
+        var tick = sliderInst.ticks[2];  // 5
+        var sliderCoords = calcTouchEventCoords(sliderElem);
+        var coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+        touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
+
+        tick = sliderInst.ticks[3];  // 7
+        coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+        touchMove = createTouchEvent(sliderElem, 'touchmove', coords);
+
+        touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+
+        sliderElem.dispatchEvent(touchStart);
+        sliderElem.dispatchEvent(touchMove);
+        sliderElem.dispatchEvent(touchEnd);
+      });
+
+    });
+
+  });
+
 });

--- a/test/specs/TouchCapableSpec.js
+++ b/test/specs/TouchCapableSpec.js
@@ -376,4 +376,108 @@ describe("Touch Capable Tests", function() {
 
   });
 
+  describe("Tooltip tests", function() {
+    var $tooltip;
+
+    describe("single slider", function() {
+
+      beforeEach(function() {
+        // Initialize the slider
+        $testSlider = $('#' + inputId).slider(sliderOptions);
+
+        // Get slider instance
+        sliderInst = $testSlider.data('slider');
+      });
+
+      // index= [0 1 2 3 4]
+      // ticks= [0 3 5 7 10]
+      it("should show the tooltip when touching the slider at value 5", function(done) {
+        var sliderElem = $testSlider.slider('getElement');
+        $tooltip = $(sliderElem).find('.tooltip.tooltip-main');
+
+        /* Note: You can't use $testSlider.on('slideStart', function() {}) because jQuery
+         * maintains its own list of event handlers and you may get unexpected results
+         * when you add event handlers using $.on() versus DOM.addEventListener()
+         * as they are called in a different order.
+         * 
+         * The browser will call the event handlers registered with addEventListener()
+         * in the order in which they are registered. For example, you'll get the following
+         * execution order when listening for "touchstart" events.
+         * 
+         * 1) _touchstart()
+         * 2) _showTooltip()
+         * 3) your event handler here
+         */
+        sliderElem.addEventListener('touchstart', function() {
+          expect($tooltip.hasClass('in')).toBe(true);
+        }, false);
+
+        $testSlider.on('slideStop', function() {
+          expect($tooltip.hasClass('in')).toBe(false);
+          done();
+        });
+
+        var tick = sliderInst.ticks[2];  // 5
+        var sliderCoords = calcTouchEventCoords(sliderElem);
+        var coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+        touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
+
+        touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+
+        sliderElem.dispatchEvent(touchStart);
+        sliderElem.dispatchEvent(touchEnd);
+      });
+
+    });
+
+    describe("range slider", function() {
+      var touchStart2;
+
+      beforeEach(function() {
+        sliderOptions.range = true;
+        sliderOptions.value = [3, 7];
+
+        // Initialize the slider
+        $testSlider = $('#' + inputId).slider(sliderOptions);
+
+        // Get slider instance
+        sliderInst = $testSlider.data('slider');
+      });
+
+      // index= [0 1 2 3 4]
+      // ticks= [0 3 5 7 10]
+      it("should show the tooltip when touching the slider at value 3 and 7", function(done) {
+        var sliderElem = $testSlider.slider('getElement');
+        $tooltip = $(sliderElem).find('.tooltip.tooltip-main');
+
+        sliderElem.addEventListener('touchstart', function() {
+          expect($tooltip.hasClass('in')).toBe(true);
+        }, false);
+
+        $testSlider.on('slideStop', function() {
+          expect($tooltip.hasClass('in')).toBe(false);
+          done();
+        });
+
+        var tick = sliderInst.ticks[1];  // 3
+        var sliderCoords = calcTouchEventCoords(sliderElem);
+        var coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+        touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
+
+        // For second handle
+        tick = sliderInst.ticks[3];  // 7
+        coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+        touchStart2 = createTouchEvent(sliderElem, 'touchstart', coords);
+
+        touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+
+        sliderElem.dispatchEvent(touchStart);
+        sliderElem.dispatchEvent(touchStart2);
+        sliderElem.dispatchEvent(touchEnd);
+      });
+
+    });
+
+  });
+
 });

--- a/test/specs/TouchCapableSpec.js
+++ b/test/specs/TouchCapableSpec.js
@@ -1,0 +1,128 @@
+/*
+    list can be either [[x, y], [x, y]] or [x, y]
+*/
+function createTouchList(target, list) {
+  if (Array.isArray(list) && list[0] && !Array.isArray(list[0])) {
+      list = [list];
+  }
+  list = list.map(function (entry, index) {
+      var x = entry[0], y = entry[1], id = entry[2] ? entry[2] : index + 1;
+      return createTouch(x, y, target, id);
+  });
+  return document.createTouchList.apply(document, list);
+}
+
+function createTouch(x, y, target, id) {
+  return document.createTouch(window, target,
+      id || 1,  //identifier
+      x,  //pageX / clientX
+      y,  //pageY / clientY
+      x,  //screenX
+      y  //screenY
+  );
+}
+
+function initTouchEvent(touchEvent, type, touches) {
+  var touch1 = touches[0];
+  return touchEvent.initTouchEvent(
+      touches, //touches
+      touches, //targetTouches
+      touches, //changedTouches
+      type, //type
+      window, //view
+      touch1.screenX, //screenX
+      touch1.screenY, //screenY
+      touch1.clientX, //clientX
+      touch1.clientY, //clientY
+      false, //ctrlKey
+      false, //altKey
+      false, //shiftKey
+      false //metaKey
+  );
+}
+
+function createTouchEvent(elem, type, touches) {
+  var touchEvent = document.createEvent('TouchEvent');
+  if (Array.isArray(touches)) {
+      touches = createTouchList(elem, touches);
+  }
+
+  initTouchEvent(touchEvent, type, touches);
+  return touchEvent;
+}
+
+function calcTouchEventCoords(element) {
+  var elementBB = element.getBoundingClientRect();
+
+  return {
+    x: elementBB.left,
+    y: elementBB.top
+  };
+}
+
+describe("Touch Capable Tests", function() {
+  var touchStart;
+  var touchMove;
+  var touchEnd;
+  var $testSlider;
+  var sliderInst;
+  var inputId = 'testSlider1';
+  var sliderId;
+  var sliderOptions;
+
+  beforeEach(function() {
+    sliderId = 'mySlider';
+
+    sliderOptions = {
+      id: sliderId,
+      step: 1,
+      value: 5,
+      ticks: [0, 3, 5, 7, 10]
+    };
+
+    // Initialize the slider
+    $testSlider = $('#' + inputId).slider(sliderOptions);
+
+    // Enable touch
+    window.ontouchstart = true;
+
+    // Get slider instance
+    sliderInst = $testSlider.data('slider');
+  });
+
+  afterEach(function() {
+    window.ontouchstart = null;
+
+    if ($testSlider) {
+      $testSlider.slider('destroy');
+      $testSlider = null;
+    }
+  });
+
+  // 0 1 2 3 4
+  // 0 3 5 7 10
+  it("should slide the handle to the left from 5 to 3", function(done) {
+    var sliderElem = $testSlider.slider('getElement');
+    $testSlider.on('slideStop', function() {
+      var value = $testSlider.slider('getValue');
+      expect(value).toBe(3);
+      done();
+    });
+
+    var tick = sliderInst.ticks[2];  // 5
+    var sliderCoords = calcTouchEventCoords(sliderElem);
+    var coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+    touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
+
+    tick = sliderInst.ticks[1];  // 3
+    coords = coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+    touchMove = createTouchEvent(sliderElem, 'touchmove', coords);
+
+    touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+
+    sliderElem.dispatchEvent(touchStart);
+    sliderElem.dispatchEvent(touchMove);
+    sliderElem.dispatchEvent(touchEnd);
+  });
+
+});

--- a/test/specs/TouchCapableSpec.js
+++ b/test/specs/TouchCapableSpec.js
@@ -310,4 +310,70 @@ describe("Touch Capable Tests", function() {
 
   });
 
+  describe("range, vertical slider", function() {
+
+    beforeEach(function() {
+      sliderOptions.range = true;
+      sliderOptions.value = [3, 7];
+      sliderOptions.orientation = 'vertical';
+
+      // Initialize the slider
+      $testSlider = $('#' + inputId).slider(sliderOptions);
+
+      // Get slider instance
+      sliderInst = $testSlider.data('slider');
+    });
+
+    // index= [0 1 2 3 4]
+    // ticks= [0 3 5 7 10]
+    it("should slide the first handle to the top from 3 to 0", function(done) {
+      var sliderElem = $testSlider.slider('getElement');
+      $testSlider.on('slideStop', function() {
+        var value = $testSlider.slider('getValue');
+        expect(value).toEqual([0, 7]);
+        done();
+      });
+
+      var tick = sliderInst.ticks[1];  // 3
+      var sliderCoords = calcTouchEventCoords(sliderElem);
+      var coords = [sliderCoords.x, sliderCoords.y + tick.offsetTop];
+      touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
+
+      tick = sliderInst.ticks[0];  // 0
+      coords = [sliderCoords.x, sliderCoords.y + tick.offsetTop];
+      touchMove = createTouchEvent(sliderElem, 'touchmove', coords);
+
+      touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+
+      sliderElem.dispatchEvent(touchStart);
+      sliderElem.dispatchEvent(touchMove);
+      sliderElem.dispatchEvent(touchEnd);
+    });
+
+    it("should slide the second handle to the bottom from 7 to 10", function(done) {
+      var sliderElem = $testSlider.slider('getElement');
+      $testSlider.on('slideStop', function() {
+        var value = $testSlider.slider('getValue');
+        expect(value).toEqual([3, 10]);
+        done();
+      });
+
+      var tick = sliderInst.ticks[3];  // 7
+      var sliderCoords = calcTouchEventCoords(sliderElem);
+      var coords = [sliderCoords.x, sliderCoords.y + tick.offsetTop];
+      touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
+
+      tick = sliderInst.ticks[4];  // 10
+      coords = [sliderCoords.x, sliderCoords.y + tick.offsetTop];
+      touchMove = createTouchEvent(sliderElem, 'touchmove', coords);
+
+      touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+
+      sliderElem.dispatchEvent(touchStart);
+      sliderElem.dispatchEvent(touchMove);
+      sliderElem.dispatchEvent(touchEnd);
+    });
+
+  });
+
 });

--- a/test/specs/TouchCapableSpec.js
+++ b/test/specs/TouchCapableSpec.js
@@ -89,13 +89,15 @@ describe("Touch Capable Tests", function() {
   var touchStart;
   var touchMove;
   var touchEnd;
+
   var $testSlider;
   var sliderInst;
-  var inputId = 'testSlider1';
+  var inputId;
   var sliderId;
   var sliderOptions;
 
   beforeEach(function() {
+    inputId = 'testSlider1';
     sliderId = 'mySlider';
 
     sliderOptions = {
@@ -105,14 +107,8 @@ describe("Touch Capable Tests", function() {
       ticks: [0, 3, 5, 7, 10]
     };
 
-    // Initialize the slider
-    $testSlider = $('#' + inputId).slider(sliderOptions);
-
     // Enable touch
     window.ontouchstart = true;
-
-    // Get slider instance
-    sliderInst = $testSlider.data('slider');
   });
 
   afterEach(function() {
@@ -124,30 +120,131 @@ describe("Touch Capable Tests", function() {
     }
   });
 
-  // 0 1 2 3 4
-  // 0 3 5 7 10
-  it("should slide the handle to the left from 5 to 3", function(done) {
-    var sliderElem = $testSlider.slider('getElement');
-    $testSlider.on('slideStop', function() {
-      var value = $testSlider.slider('getValue');
-      expect(value).toBe(3);
-      done();
+  describe("single slider", function() {
+
+    beforeEach(function() {
+      // Initialize the slider
+      $testSlider = $('#' + inputId).slider(sliderOptions);
+
+      // Get slider instance
+      sliderInst = $testSlider.data('slider');
     });
 
-    var tick = sliderInst.ticks[2];  // 5
-    var sliderCoords = calcTouchEventCoords(sliderElem);
-    var coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
-    touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
+    // index= [0 1 2 3 4]
+    // ticks= [0 3 5 7 10]
+    it("should slide the handle to the left from 5 to 3", function(done) {
+      var sliderElem = $testSlider.slider('getElement');
+      $testSlider.on('slideStop', function() {
+        var value = $testSlider.slider('getValue');
+        expect(value).toBe(3);
+        done();
+      });
 
-    tick = sliderInst.ticks[1];  // 3
-    coords = coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
-    touchMove = createTouchEvent(sliderElem, 'touchmove', coords);
+      var tick = sliderInst.ticks[2];  // 5
+      var sliderCoords = calcTouchEventCoords(sliderElem);
+      var coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+      touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
 
-    touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+      tick = sliderInst.ticks[1];  // 3
+      coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+      touchMove = createTouchEvent(sliderElem, 'touchmove', coords);
 
-    sliderElem.dispatchEvent(touchStart);
-    sliderElem.dispatchEvent(touchMove);
-    sliderElem.dispatchEvent(touchEnd);
+      touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+
+      sliderElem.dispatchEvent(touchStart);
+      sliderElem.dispatchEvent(touchMove);
+      sliderElem.dispatchEvent(touchEnd);
+    });
+
+    it("should slide the handle to the right from 5 to 7", function(done) {
+      var sliderElem = $testSlider.slider('getElement');
+      $testSlider.on('slideStop', function() {
+        var value = $testSlider.slider('getValue');
+        expect(value).toBe(7);
+        done();
+      });
+
+      var tick = sliderInst.ticks[2];  // 5
+      var sliderCoords = calcTouchEventCoords(sliderElem);
+      var coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+      touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
+
+      tick = sliderInst.ticks[3];  // 7
+      coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+      touchMove = createTouchEvent(sliderElem, 'touchmove', coords);
+
+      touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+
+      sliderElem.dispatchEvent(touchStart);
+      sliderElem.dispatchEvent(touchMove);
+      sliderElem.dispatchEvent(touchEnd);
+    });
+
+  });
+
+  describe("range slider", function() {
+
+    beforeEach(function() {
+      sliderOptions.range = true;
+      sliderOptions.value = [3, 7];
+
+      // Initialize the slider
+      $testSlider = $('#' + inputId).slider(sliderOptions);
+
+      // Get slider instance
+      sliderInst = $testSlider.data('slider');
+    });
+
+    // index= [0 1 2 3 4]
+    // ticks= [0 3 5 7 10]
+    it("should slide the first handle to the left from 3 to 0", function(done) {
+      var sliderElem = $testSlider.slider('getElement');
+      $testSlider.on('slideStop', function() {
+        var value = $testSlider.slider('getValue');
+        expect(value).toEqual([0, 7]);
+        done();
+      });
+
+      var tick = sliderInst.ticks[1];  // 3
+      var sliderCoords = calcTouchEventCoords(sliderElem);
+      var coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+      touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
+
+      tick = sliderInst.ticks[0];  // 0
+      coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+      touchMove = createTouchEvent(sliderElem, 'touchmove', coords);
+
+      touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+
+      sliderElem.dispatchEvent(touchStart);
+      sliderElem.dispatchEvent(touchMove);
+      sliderElem.dispatchEvent(touchEnd);
+    });
+
+    it("should slide the second handle to the right from 7 to 10", function(done) {
+      var sliderElem = $testSlider.slider('getElement');
+      $testSlider.on('slideStop', function() {
+        var value = $testSlider.slider('getValue');
+        expect(value).toEqual([3, 10]);
+        done();
+      });
+
+      var tick = sliderInst.ticks[3];  // 7
+      var sliderCoords = calcTouchEventCoords(sliderElem);
+      var coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+      touchStart = createTouchEvent(sliderElem, 'touchstart', coords);
+
+      tick = sliderInst.ticks[4];  // 10
+      coords = [sliderCoords.x + tick.offsetLeft, sliderCoords.y];
+      touchMove = createTouchEvent(sliderElem, 'touchmove', coords);
+
+      touchEnd = createTouchEvent(sliderElem, 'touchend', coords);
+
+      sliderElem.dispatchEvent(touchStart);
+      sliderElem.dispatchEvent(touchMove);
+      sliderElem.dispatchEvent(touchEnd);
+    });
+
   });
 
 });

--- a/test/specs/TouchCapableSpec.js
+++ b/test/specs/TouchCapableSpec.js
@@ -1,3 +1,28 @@
+/* The following functions are taken and slightly modified from mock-phantom-touch-events.
+ * 
+ * The original mock-phantom-touch-events can be found at https://github.com/gardr/mock-phantom-touch-events
+ * 
+ * mock-phantom-touch-events is licensed under:
+ * 
+ * The MIT License (MIT)
+ * Copyright (c) 2013 FINN.no AS
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
 /*
     list can be either [[x, y], [x, y]] or [x, y]
 */

--- a/tpl/SpecRunner.tpl
+++ b/tpl/SpecRunner.tpl
@@ -26,6 +26,16 @@
 			padding: 2000px 0 500px 0;
 		}
 
+		#horz-scroll-div {
+			overflow-x: scroll;
+			width: 300px;
+			height: 150px;
+		}
+		#vert-scroll-div {
+			overflow-y: scroll;
+			width: 150px;
+			height: 300px;
+		}
 	</style>
 </head>
 <body>
@@ -94,6 +104,16 @@
 		<p>just a row</p>
 		<p>just a row</p>
 		<input id="ex1" data-slider-id='ex1Slider' type="text"/>
+	</div>
+
+	<div id="horz-scroll-div">
+		<input id="horz-touch-slider" type="text"/>
+		<div style="position: relative; left: 1000px">Text</div>
+	</div>
+
+	<div id="vert-scroll-div">
+		<input id="vert-touch-slider" type="text"/>
+		<div style="position: relative; top: 1000px">More text</div>
 	</div>
 
 	<div id="low-div">


### PR DESCRIPTION
This pull request addresses these issues:

Page scrolling: https://github.com/seiyria/bootstrap-slider/issues/639
Passive listeners: https://github.com/seiyria/bootstrap-slider/issues/842

Tooltips not displaying on touch-enabled mobile devices:
https://github.com/seiyria/bootstrap-slider/issues/513
https://github.com/seiyria/bootstrap-slider/issues/765

* I removed the passive listener check because the intention is to stop the page from scrolling while dragging the slider on touch devices (Which was added here: https://github.com/seiyria/bootstrap-slider/pull/680)
* I've removed the initialization code and touch movement checks in `_touchstart()` and `_touchmove()` just to see if the code would work. @rovolution Is this code meant for browser compatibility and performance?
https://github.com/seiyria/bootstrap-slider/blob/642b40f80790b7c82e9ff149cdf07e40907ccd34/src/js/bootstrap-slider.js#L1585-L1594
https://github.com/seiyria/bootstrap-slider/blob/642b40f80790b7c82e9ff149cdf07e40907ccd34/src/js/bootstrap-slider.js#L1683-L1703
* Most of the changes are based on this tutorial on MDN: https://developer.mozilla.org/en-US/docs/Web/API/Touch_events
* I updated the `dist` folder so I can demo the changes on my project page
* Debug statements I can always remove

You can check my project page to test the latest changes from this branch: https://jespirit.github.io/bootstrap-slider/. I've tested it mobile devices using Chrome's Device Mode.

I also tested it on my Samsung A5 (2017), Android 8.0.0

Unit tests...

Edit:
* Calling `preventDefault()` inside of `'touchmove'` event will prevent the page from scrolling and will not send a corresponding `'mousemove'`. However, event listeners are set up in `_mousedown()` to call `_mousemove()` on `'touchmove'` events.
https://github.com/seiyria/bootstrap-slider/blob/642b40f80790b7c82e9ff149cdf07e40907ccd34/src/js/bootstrap-slider.js#L1561-L1565


Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [ ] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [ ] Link to original Github issue (if this is a bug-fix)
- [ ] documentation updates to README file
- [ ] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
