### PR TITLE
Add new feature to persist the value after a refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ __NOTE:__ Optional parameters are italicized.
 | isEnabled | --- |Returns true if enabled, false if disabled |
 | setAttribute | attribute, value | Updates the slider's [attributes](#options) |
 | getAttribute | attribute | Get the slider's [attributes](#options) |
-| refresh | --- | Refreshes the current slider |
+| refresh | _options_ | Refreshes the current slider and resets the slider's value to its default value on initial setup. To override this behaviour and instead maintain the slider's current value, pass the optional `options` parameter with the property `useCurrentValue` set to `true` (eg. `refresh({ useCurrentValue: true })`. |
 | on | eventType, callback | When the slider event _eventType_ is triggered, the callback function will be invoked |
 | off | eventType, callback | Removes the callback function from the slider event _eventType_ |
 | relayout | --- | Renders the tooltip again, after initialization. Useful in situations when the slider and tooltip are initially hidden. |

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1079,9 +1079,14 @@ const windowIsDefined = (typeof window === "object");
 				return this;
 			},
 
-			refresh: function() {
+			refresh: function(options) {
+				var currentValue = this.getValue();
 				this._removeSliderEventHandlers();
 				createNewSlider.call(this, this.element, this.options);
+				// Don't reset slider's value on refresh if `useCurrentValue` is true
+				if (options && options.useCurrentValue === true) {
+					this.setValue(currentValue);
+				}
 				if($) {
 					// Bind new instance of slider to the element
 					if (autoRegisterNamespace === NAMESPACE_MAIN) {

--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -1080,7 +1080,7 @@ const windowIsDefined = (typeof window === "object");
 			},
 
 			refresh: function(options) {
-				var currentValue = this.getValue();
+				const currentValue = this.getValue();
 				this._removeSliderEventHandlers();
 				createNewSlider.call(this, this.element, this.options);
 				// Don't reset slider's value on refresh if `useCurrentValue` is true

--- a/test/specs/RefreshMethodSpec.js
+++ b/test/specs/RefreshMethodSpec.js
@@ -1,5 +1,20 @@
 describe("refresh() Method Tests", function() {
   var testSlider;
+  var options;
+  var initialValue, initialRangeValue;
+
+  beforeEach(function() {
+    initialValue = 5;
+    initialRangeValue = [4, 5];
+
+    options = {
+      id: 'mySlider',
+      min: 0,
+      max: 10,
+      step: 1,
+      value: initialValue,
+    };
+  });
 
   afterEach(function() {
     if(testSlider) {
@@ -29,6 +44,52 @@ describe("refresh() Method Tests", function() {
     sliderIsRangeValue = afterRefreshValue instanceof Array;
 
     expect(sliderIsRangeValue).toBeFalsy();
+  });
+
+  it("should reset slider to its default value on refresh", function() {
+    // Initialize non-range slider
+    testSlider = new Slider('#testSlider1', options);
+
+    testSlider.setValue(7, true, true);
+    testSlider.refresh();
+
+    expect(testSlider.getValue()).toBe(initialValue);
+  });
+
+  it("should maintain its current value on refresh", function() {
+    var newValue = 7;
+    // Initialize non-range slider
+    testSlider = new Slider('#testSlider1', options);
+
+    testSlider.setValue(newValue, true, true);
+    testSlider.refresh({ useCurrentValue: true });
+
+    expect(testSlider.getValue()).toBe(newValue);
+  });
+
+  it("should reset slider to its default value on refresh (range)", function() {
+    // Initialize range slider
+    options.value = initialRangeValue;
+    options.range = true;
+    testSlider = new Slider('#testSlider1', options);
+
+    testSlider.setValue([7, 10], true, true);
+    testSlider.refresh();
+
+    expect(testSlider.getValue()).toBe(initialRangeValue);
+  });
+
+  it("should maintain its current value on refresh (range)", function() {
+    var newRangeValue = [7, 10];
+    // Initialize range slider
+    options.value = initialRangeValue;
+    options.range = true;
+    testSlider = new Slider('#testSlider1', options);
+
+    testSlider.setValue(newRangeValue, true, true);
+    testSlider.refresh({ useCurrentValue: true });
+
+    expect(testSlider.getValue()).toBe(newRangeValue);
   });
 
 }); // End of spec

--- a/test/specs/RefreshMethodSpec.js
+++ b/test/specs/RefreshMethodSpec.js
@@ -2,17 +2,20 @@ describe("refresh() Method Tests", function() {
   var testSlider;
   var options;
   var initialValue, initialRangeValue;
+  var newValue, newRangeValue;
 
   beforeEach(function() {
     initialValue = 5;
     initialRangeValue = [4, 5];
+    newValue = 7;
+    newRangeValue = [7, 10];
 
     options = {
       id: 'mySlider',
       min: 0,
       max: 10,
       step: 1,
-      value: initialValue,
+      value: initialValue
     };
   });
 
@@ -50,14 +53,13 @@ describe("refresh() Method Tests", function() {
     // Initialize non-range slider
     testSlider = new Slider('#testSlider1', options);
 
-    testSlider.setValue(7, true, true);
+    testSlider.setValue(newValue, true, true);
     testSlider.refresh();
 
     expect(testSlider.getValue()).toBe(initialValue);
   });
 
   it("should maintain its current value on refresh", function() {
-    var newValue = 7;
     // Initialize non-range slider
     testSlider = new Slider('#testSlider1', options);
 
@@ -73,14 +75,13 @@ describe("refresh() Method Tests", function() {
     options.range = true;
     testSlider = new Slider('#testSlider1', options);
 
-    testSlider.setValue([7, 10], true, true);
+    testSlider.setValue(newRangeValue, true, true);
     testSlider.refresh();
 
     expect(testSlider.getValue()).toBe(initialRangeValue);
   });
 
   it("should maintain its current value on refresh (range)", function() {
-    var newRangeValue = [7, 10];
     // Initialize range slider
     options.value = initialRangeValue;
     options.range = true;

--- a/test/specs/RefreshMethodSpec.js
+++ b/test/specs/RefreshMethodSpec.js
@@ -1,5 +1,6 @@
 describe("refresh() Method Tests", function() {
   var testSlider;
+  var $testSlider;
   var options;
   var initialValue, initialRangeValue;
   var newValue, newRangeValue;
@@ -22,6 +23,11 @@ describe("refresh() Method Tests", function() {
   afterEach(function() {
     if(testSlider) {
       testSlider.destroy();
+      testSlider = null;
+    }
+    if ($testSlider) {
+      $testSlider.slider('destroy');
+      $testSlider = null;
     }
   });
 
@@ -67,6 +73,26 @@ describe("refresh() Method Tests", function() {
     testSlider.refresh({ useCurrentValue: true });
 
     expect(testSlider.getValue()).toBe(newValue);
+  });
+
+  it("should reset slider to its default value on refresh (jQuery)", function() {
+    // Initialize non-range slider
+    $testSlider = $('#testSlider1').slider(options);
+
+    $testSlider.slider('setValue', newValue, true, true);
+    $testSlider.slider('refresh');
+
+    expect($testSlider.slider('getValue')).toBe(initialValue);
+  });
+
+  it("should maintain its current value on refresh (jQuery)", function() {
+    // Initialize non-range slider
+    $testSlider = $('#testSlider1').slider(options);
+
+    $testSlider.slider('setValue', newValue, true, true);
+    $testSlider.slider('refresh', { useCurrentValue: true });
+
+    expect($testSlider.slider('getValue')).toBe(newValue);
   });
 
   it("should reset slider to its default value on refresh (range)", function() {

--- a/tpl/index.tpl
+++ b/tpl/index.tpl
@@ -312,6 +312,10 @@
 		  <td><a href="#example-25">Example 25</a></td>
 		  <td>Lock selection to ticks</td>
 		</tr>
+		<tr>
+			<td><a href="#example-26">Example 26</a></td>
+			<td>Refresh method with optional `options` object</td>
+		</tr>
       </table>
 	  
       <div class="examples">
@@ -1269,6 +1273,35 @@ $("#ex25").slider({
 </pre></code>
 		  </div>
 
+			<div id="example-26" class='slider-example'>
+				<h3>Example 26: <a href="#top"><small>Back to Top</small></a></h3>
+				<p>Refresh method with optional `options` object</p>
+				<div class="well">
+					<input id="ex26" data-slider-id="ex26Slider" type="text" data-slider-min="0" data-slider-max="20" data-slider-step="1" data-slider-value="10"/>
+					<button id="ex26_Refresh" class='btn btn-primary'>Refresh</button>
+					<div class="form-check">
+						<input class="form-check-input" type="checkbox" value="" id="ex26_UseCurrentVal">
+						<label class="form-check-label" for="ex26_UseCurrentVal">
+							Use Current Value
+						</label>
+					</div>
+				</div>
+<h5>HTML</h5>
+<pre><code class="html">
+&lt;input id="ex26" data-slider-id="ex26Slider" type="text" data-slider-min="0" data-slider-max="20" data-slider-step="1" data-slider-value="10"/&gt;
+</code></pre>
+
+<h5>JavaScript</h5>
+<pre><code class="js">
+// With JQuery
+$('#ex26').slider('refresh', { useCurrentValue: true });
+
+// Without JQuery
+var slider = new Slider('#ex26');
+slider.refresh({ useCurrentValue: true });
+</code></pre>
+			</div> <!-- /example-26 -->
+
 	  </div> <!-- /examples -->
     </div> <!-- /container -->
 
@@ -1478,6 +1511,18 @@ $("#ex25").slider({
 				value: [1, 100],
 				ticks: [1, 50, 100],
 				lock_to_ticks: true
+			});
+
+			/* example 26 */
+			$('#ex26').slider();
+
+			$('#ex26_Refresh').on('click', function() {
+				if ($('#ex26_UseCurrentVal').prop('checked')) {
+					$('#ex26').slider('refresh', { useCurrentValue: true });
+				}
+				else {
+					$('#ex26').slider('refresh');
+				}
 			});
 		});
     </script>


### PR DESCRIPTION
Closes #901.

The user can pass an object with the property `useCurrentValue` set to
`true` so that the slider maintains its value after a call to `refresh`.

~~I will add an example as well.~~ Done.

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [x] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [x] Link to original Github issue (if this is a bug-fix)
- [x] documentation updates to README file
- [x] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
