### PR TITLE
Add webpack encore config

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ resolve: {
 }
 ```
 
+### [Webpack-encore](https://symfony.com/doc/current/frontend.html)
+```js
+Encore
+    // directory where compiled assets will be stored
+    .setOutputPath('public/build/')
+    // ...
+    webpack-encore config
+    ...
+;
+
+const config = Encore.getWebpackConfig();
+config.resolve.alias["jquery"] = path.resolve(__dirname, 'assets/js/jquery-stub.js');
+module.exports = config
+```
+
 Then in your project, you will have to create a stub module for jquery that exports a `null` value. Whenever `require("jquery")` is mentioned in your project, it will load this stubbed module.
 
 ```js


### PR DESCRIPTION
I use webpack-encore in my projects. I found a way to use this plugin without jQuery.


Nota: works for now with BS5

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [ ] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [ ] Link to original Github issue (if this is a bug-fix)
- [ ] documentation updates to README file
- [ ] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
