### PR TITLE
preventOverflow flag to offset tooltips to stay within viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Options can be passed either as a data (data-slider-foo) attribute, or as part o
 | tooltip |	string |	'show' |	whether to show the tooltip on drag, hide the tooltip, or always show the tooltip. Accepts: 'show', 'hide', or 'always' |
 | tooltip_split |	bool |	false |	if false show one tootip if true show two tooltips one for each handler |
 | tooltip_position |	string |	null |	Position of tooltip, relative to slider. Accepts 'top'/'bottom' for horizontal sliders and 'left'/'right' for vertically orientated sliders. Default positions are 'top' for horizontal and 'right' for vertical slider. |
+| preventOverflow | bool | false | whether to shift tooltips to keep them within the viewport, similar to Popper.js's [`preventOverflow` modifier](https://popper.js.org/docs/v2/modifiers/prevent-overflow/)
 | handle |	string |	'round' |	handle shape. Accepts: 'round', 'square', 'triangle' or 'custom' |
 | reversed | bool | false | whether or not the slider should be reversed |
 | rtl | string, bool| 'auto' | whether or not the slider should be shown in rtl mode. Accepts true, false, 'auto'. Default 'auto' : use actual direction of HTML (`dir='rtl'`) |


### PR DESCRIPTION
This PR fixes #649 and in some sense fixes #952.

I initially tried the second or third approach outlined in #952, but realized that it would be difficult to actually use Popper.js.  `createPopper` requires a DOM element to anchor the tooltip to, and in some uses of bootstrap-slider, there isn't a tick associated with the position being tooltipped.  We could create an artificial tooltip position DOM element to give to `createPopper`, but I instead tried a fourth approach:

4. Implement the logic of [`preventOverflow`](https://popper.js.org/docs/v2/modifiers/prevent-overflow/) manually.

This achieves the goal of no dependencies, adding a fairly small amount of code for nice functionality, hidden within a new `preventOverflow` option. I didn't change the defaults because it would break a lot of tests and backward compatibility, but happy to change.

I did not implement [flip](https://popper.js.org/docs/v2/modifiers/prevent-overflow/) yet, mainly because I care about it less. I could work on it if desired.

I've gotten this working well in my project (via `npm link`), which uses left-to-right horizontal sliders and always-shown tooltips.  Here are some screenshots

context | screenshot
---|---
left extreme | ![image](https://user-images.githubusercontent.com/2218736/105533975-d3156800-5cba-11eb-8862-40087c8ea4a8.png)
right extreme (including scrollbar) | ![image](https://user-images.githubusercontent.com/2218736/105533850-acefc800-5cba-11eb-83a8-f0d44d9165df.png)
in the middle | ![image](https://user-images.githubusercontent.com/2218736/105533900-bbd67a80-5cba-11eb-9bd4-f0478a0e1308.png)

As this is my first contribution, I could use some guidance on how to test more thoroughly/broadly, and these PR requests:

- [ ] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [ ] Link to original Github issue (if this is a bug-fix)
- [ ] documentation updates to README file
- [ ] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
