### PR TITLE
Update _mixins.scss

### DIFF
--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -1,25 +1,19 @@
-@mixin slider_background-image ($colorstart:#F5F5F5, $colorend:#F9F9F9, $backcolor: #F7F7F7) {
+@mixin slider-background-image($colorstart: #F5F5F5, $colorend: #F9F9F9, $backcolor: #F7F7F7) {
   background-color: $backcolor;
-  background-image: -moz-linear-gradient(top, $colorstart, $colorend);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from($colorstart), to($colorend));
-  background-image: -webkit-linear-gradient(top, $colorstart, $colorend);
-  background-image: -o-linear-gradient(top, $colorstart, $colorend);
   background-image: linear-gradient(to bottom, $colorstart, $colorend);
   background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$colorstart}', endColorstr='#{$colorend}',GradientType=0);
+  // Fallback for IE9 and below
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$colorstart}', endColorstr='#{$colorend}', GradientType=0);
 }
-@mixin slider_box-sizing ($value) {
-  -webkit-box-sizing: $value;
-  -moz-box-sizing: $value;
+
+@mixin slider-box-sizing($value) {
   box-sizing: $value;
 }
-@mixin slider_box-shadow ($value...) {
-  -webkit-box-shadow: $value;
-  -moz-box-shadow: $value;
+
+@mixin slider-box-shadow($value...) {
   box-shadow: $value;
 }
-@mixin slider_border-radius ($value) {
-  -webkit-border-radius: $value;
-  -moz-border-radius: $value;
+
+@mixin slider-border-radius($value) {
   border-radius: $value;
 }


### PR DESCRIPTION
Removed outdated vendor prefixes: Modern browsers no longer need the -webkit-, -moz-, and -o- prefixes for linear-gradient, box-sizing, box-shadow, and border-radius. These properties are now well-supported without prefixes.
Retained filter for IE9: Kept the filter property for older versions of Internet Explorer.

Explanation:
slider-background-image: Sets a gradient background with a fallback for older versions of Internet Explorer. slider-box-sizing: Sets the box-sizing property.
slider-box-shadow: Sets the box-shadow property, allowing multiple values using the SCSS variadic arguments feature.

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [x] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [ ] Link to original Github issue (if this is a bug-fix)
- [ ] documentation updates to README file
- [ ] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
