### PR TITLE
Fixed deprecation warnings for division and darken/lighten

### DIFF
--- a/src/sass/_rules.scss
+++ b/src/sass/_rules.scss
@@ -6,9 +6,9 @@
     width: $slider-horizontal-width;
     height: $slider-line-height;
     .slider-track {
-      height: $slider-line-height/2;
+      height: calc($slider-line-height/2);
       width: 100%;
-      margin-top: -$slider-line-height/4;
+      margin-top: - calc($slider-line-height/4);
       top:  50%;
       left: 0;
     }
@@ -19,12 +19,12 @@
     }
     .slider-tick,
     .slider-handle {
-      margin-left: -$slider-line-height/2;
+      margin-left: - calc($slider-line-height/2);
       &.triangle {
         position: relative;
         top: 50%;
         transform: translateY(-50%);
-        border-width: 0 $slider-line-height/2 $slider-line-height/2 $slider-line-height/2;
+        border-width: 0 calc($slider-line-height/2) calc($slider-line-height/2) calc($slider-line-height/2);
         width: 0;
         height: 0;
         border-bottom-color: $slider-primary-bottom;
@@ -54,7 +54,7 @@
       .slider-tick,
       .slider-handle {
         margin-left: initial;
-        margin-right: -$slider-line-height/2;
+        margin-right: - calc($slider-line-height/2);
       }
       .slider-tick-container {
         left: initial;
@@ -66,7 +66,7 @@
     height: $slider-vertical-height;
     width: $slider-line-height;
     .slider-track {
-      width: $slider-line-height/2;
+      width: calc($slider-line-height/2);
       height: 100%;
       left: 25%;
       top: 0;
@@ -84,9 +84,9 @@
     }
     .slider-tick,
     .slider-handle {
-      margin-top: -$slider-line-height/2;
+      margin-top: - calc($slider-line-height/2);
       &.triangle {
-        border-width: $slider-line-height/2 0 $slider-line-height/2 $slider-line-height/2;
+        border-width: calc($slider-line-height/2) 0 calc($slider-line-height/2) calc($slider-line-height/2);
         width:  1px;
         height: 1px;
         border-left-color: $slider-primary-bottom;
@@ -111,7 +111,7 @@
       .slider-tick,
       .slider-handle {
         &.triangle {
-          border-width: $slider-line-height/2 $slider-line-height/2 $slider-line-height/2 0;
+          border-width: calc($slider-line-height/2) calc($slider-line-height/2) calc($slider-line-height/2) 0;
         }
       }
       .slider-tick-label-container {

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $slider-line-height: 20px !default;
 $slider-border-radius: 4px !default;
 $slider-horizontal-width: 210px !default;
@@ -12,9 +14,9 @@ $slider-primary: null !default;
 }
 
 $slider-primary-top: $slider-primary !default;
-$slider-primary-bottom: darken($slider-primary, 5%) !default;
-$slider-secondary-top: saturate(lighten($slider-primary, 28%), 20%) !default;
-$slider-secondary-bottom: saturate(lighten($slider-primary, 23%), 2%) !default;
+$slider-primary-bottom: color.scale($slider-primary, $lightness: -5%) !default;
+$slider-secondary-top: saturate(color.scale($slider-primary, $lightness: 28%), 20%) !default;
+$slider-secondary-bottom: saturate(color.scale($slider-primary, $lightness: 23%), 2%) !default;
 
 // grays for slider channel and disabled states
 $slider-gray-1: #BEBEBE !default;


### PR DESCRIPTION
These deprecation warnings should be fixed:
> Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

> Deprecation Warning: darken() is deprecated

> Deprecation Warning: lighten() is deprecated.

My apologies for not ticking any of the below boxes. I understand if this PR will be ignored. But at least I tried 😄 
We're using this library for work, and I don't have time allocated to set up Jasmine, run unit-tests, and provide examples.

Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [ ] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [ ] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [ ] Link to original Github issue (if this is a bug-fix)
- [ ] documentation updates to README file
- [ ] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [ ] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
