### PR TITLE
Fix JQuery 3.3 deprecation:

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -158,7 +158,7 @@ const windowIsDefined = (typeof window === "object");
 			            "attempted to call '" + options + "'" );
 			          continue;
 			        }
-			        if ( !$.isFunction( instance[options] ) || options.charAt(0) === '_' ) {
+			        if ( !(typeof( instance[options] ) === 'function') || options.charAt(0) === '_' ) {
 			          logError( "no such method '" + options + "' for " + namespace + " instance" );
 			          continue;
 			        }
@@ -1645,10 +1645,10 @@ const windowIsDefined = (typeof window === "object");
 			},
 			_triggerFocusOnHandle: function(handleIdx) {
 				if(handleIdx === 0) {
-					this.handle1.focus();
+					this.handle1.trigger('focus');
 				}
 				if(handleIdx === 1) {
-					this.handle2.focus();
+					this.handle2.trigger('focus');
 				}
 			},
 			_keydown: function(handleIdx, ev) {


### PR DESCRIPTION
- use trigger('focus') instead of focus(). See https://api.jquery.com/focus-shorthand/
- use typeof to check if option is a function instead of $.isFunction. See https://api.jquery.com/jQuery.isFunction/


Pull Requests
=============
Please accompany all pull requests with the following (where appropriate):

- [x] unit tests (we use [Jasmine 2.x.x](https://jasmine.github.io/2.2/introduction))
- [x] JSFiddle (or an equivalent such as CodePen, Plunker, etc) or screenshot/GIF with new feature or bug-fix
- [x] Link to original Github issue (if this is a bug-fix)
- [x] documentation updates to README file
- [x] examples within [/tpl/index.tpl](https://github.com/seiyria/bootstrap-slider/blob/master/tpl/index.tpl) (for new options being added)
- [x] Passes CI-server checks (runs automated tests, JS source-code linting, etc..). To run these on your local machine, type `grunt test` in your Terminal within the bootstrap-slider repository directory
